### PR TITLE
Fixed a bug that would make flashing tiny images fail

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -340,7 +340,7 @@ if __name__ == '__main__':
         print 'Erasing flash...'
         esp.flash_begin(len(image), args.address)
         seq = 0
-        blocks = math.ceil(len(image)/esp.ESP_FLASH_BLOCK)
+        blocks = math.ceil(len(image)/float(esp.ESP_FLASH_BLOCK))
         while len(image) > 0:
             print '\rWriting at 0x%08x... (%d %%)' % (args.address + seq*esp.ESP_FLASH_BLOCK, 100*seq/blocks),
             sys.stdout.flush()


### PR DESCRIPTION
When flashing very small images (i.e. size < `ESP_FLASH_BLOCK`) python would handle `ESP_FLASH_BLOCK` as an integer thus leaving the block-count at 0.
