### PR TITLE
Force python2 and fix flash_finish problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,18 @@ Byte   | Name		| Comment
 -------|----------------|-------------------------------
 0      | Direction	| Always `0x01` for responses
 1      | Command	| Same value as in the request packet that trigged the response
-2-3    | Size		| Size of body
+2-3    | Size		| Size of body, normally 2
 4-7    | Value		| Response data for some operations
 8..n   | Body		| Depends on operation
+8      | Status		| Status flag, success(0) or failure(1)
+9      | Error		| Last error code, not reset on success
 
 ### Opcodes
 
 Byte   | Name			| Input		| Output
 -------|------------------------|---------------|------------------------
-`0x02` | Flash Download Start	| total size, 0x200, block size, offset	|
-`0x03` | Flash Download Data	| size, sequence number, data. checksum in dedicated field. |
+`0x02` | Flash Download Start	| total size, number of blocks, block size, offset	|
+`0x03` | Flash Download Data	| size, sequence number, data. checksum in value field. |
 `0x04` | Flash Download Finish	| reboot flag? |
 `0x05` | RAM Download Start	| total size, packet size, number of packets, memory offset |
 `0x06` | RAM Download Finish	| execute flag, entry point |
@@ -72,6 +74,7 @@ Byte   | Name			| Input		| Output
 `0x08` | Sync Frame		| `0x07 0x07 0x12 0x20`, `0x55` 32 times |
 `0x09` | Write register		| Four 32-bit words: address, value, mask and delay (in microseconds) | Body is `0x00 0x00` if successful
 `0x0a` | Read register		| Address as 32-bit word | Read data as 32-bit word in `value` field
+`0x0b` | Configure SPI params	| 24 bytes of unidentified SPI parameters |
 
 ### Checksum
 Each byte in the payload is XOR'ed together, as well as the magic number `0xEF`.

--- a/esptool.py
+++ b/esptool.py
@@ -171,9 +171,10 @@ class ESPROM:
     """ Start downloading to Flash (performs an erase) """
     def flash_begin(self, size, offset):
         old_tmo = self._port.timeout
+        num_blocks = (size + ESPROM.ESP_FLASH_BLOCK - 1) / ESPROM.ESP_FLASH_BLOCK
         self._port.timeout = 10
         if self.command(ESPROM.ESP_FLASH_BEGIN,
-                struct.pack('<IIII', size, 0x200, 0x400, offset))[1] != "\0\0":
+                struct.pack('<IIII', size, num_blocks, ESPROM.ESP_FLASH_BLOCK, offset))[1] != "\0\0":
             raise Exception('Failed to enter Flash download mode')
         self._port.timeout = old_tmo
 
@@ -186,8 +187,7 @@ class ESPROM:
     """ Leave flash mode and run/reboot """
     def flash_finish(self, reboot = False):
         pkt = struct.pack('<I', int(not reboot))
-        res = self.command(ESPROM.ESP_FLASH_END, pkt)
-        if res[1] not in ("\0\0", "\x01\x06"):
+        if self.command(ESPROM.ESP_FLASH_END, pkt)[1] != "\0\0":
             raise Exception('Failed to leave Flash mode')
 
     """ Run application code in flash """


### PR DESCRIPTION
It turns out the second parameter is the number of calls to finish_block.

Using python2 probably works on all modern OSes (where hashbangs are supported).
