### PR TITLE
Hard reset on disconnect

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -177,6 +177,11 @@ class ESPROM:
                     time.sleep(0.05)
         raise FatalError('Failed to connect to ESP8266')
 
+    def disconnect(self):
+        print 'Disconnecting...'
+        self._port.setRTS(True)
+        self._port.setDTR(True)
+        
     """ Read memory address in target """
     def read_reg(self, addr):
         res = self.command(ESPROM.ESP_READ_REG, struct.pack('<I', addr))
@@ -807,6 +812,7 @@ def main():
         esp = ESPROM(args.port, args.baud)
         esp.connect()
         operation_func(esp, args)
+        esp.disconnect()
     else:
         operation_func(args)
 

--- a/esptool.py
+++ b/esptool.py
@@ -825,7 +825,7 @@ class AddrFilenamePairAction(argparse.Action):
             except ValueError as e:
                 raise argparse.ArgumentError(self,'Address "%s" must be a number' % values[i])
             try:
-                argfile = open(values[i + 1], 'r')
+                argfile = open(values[i + 1], 'rb')
             except IOError as e:
                 raise argparse.ArgumentError(self, e)
             except IndexError:

--- a/esptool.py
+++ b/esptool.py
@@ -181,7 +181,7 @@ class ESPROM:
         print 'Disconnecting...'
         self._port.setRTS(True)
         self._port.setDTR(True)
-        
+
     """ Read memory address in target """
     def read_reg(self, addr):
         res = self.command(ESPROM.ESP_READ_REG, struct.pack('<I', addr))


### PR DESCRIPTION
argfile doesn't open as binary file without 'rb' and flashing fails (at least using Python 2.7.9 and Windows)
