### PR TITLE
Manual Reset Flag

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -158,14 +158,14 @@ class ESPROM:
         self.in_bootloader = True
 
     """ Try connecting repeatedly until successful, or giving up """
-    def connect(self):
+    def connect(self, manual_reset=False):
         print 'Connecting...'
 
         for _ in xrange(4):
             # issue reset-to-bootloader:
             # RTS = either CH_PD or nRESET (both active low = chip in reset)
             # DTR = GPIO0 (active low = boot to flasher)
-            if(!args.no_flow_control):
+            if manual_reset==False:
                 self._port.setDTR(False)
                 self._port.setRTS(True)
                 time.sleep(0.05)
@@ -868,7 +868,7 @@ def main():
         type=arg_auto_int,
         default=os.environ.get('ESPTOOL_BAUD', ESPROM.ESP_ROM_BAUD))
 
-    parser.add_argument('--no_flow_control', help='Do not toggle DST/RST lines (this sometimes puts serial ports in broken states)', action='store_true')
+    parser.add_argument('--manual_reset', help='Do not toggle DTR/RTS lines (this sometimes puts serial ports in broken states). Using this requires that the ESP8266 be manually reset into bootloader mode', action='store_true')
 
     subparsers = parser.add_subparsers(
         dest='operation',
@@ -988,7 +988,7 @@ def main():
     operation_args,_,_,_ = inspect.getargspec(operation_func)
     if operation_args[0] == 'esp':  # operation function takes an ESPROM connection object
         esp = ESPROM(args.port, args.baud)
-        esp.connect()
+        esp.connect(args.manual_reset)
         operation_func(esp, args)
     else:
         operation_func(args)

--- a/esptool.py
+++ b/esptool.py
@@ -165,14 +165,14 @@ class ESPROM:
             # issue reset-to-bootloader:
             # RTS = either CH_PD or nRESET (both active low = chip in reset)
             # DTR = GPIO0 (active low = boot to flasher)
-            self._port.setDTR(False)
-            self._port.setRTS(True)
-            time.sleep(0.05)
-            self._port.setDTR(True)
-            self._port.setRTS(False)
-            time.sleep(0.05)
-            self._port.setDTR(False)
-
+            if(!args.no_flow_control):
+                self._port.setDTR(False)
+                self._port.setRTS(True)
+                time.sleep(0.05)
+                self._port.setDTR(True)
+                self._port.setRTS(False)
+                time.sleep(0.05)
+                self._port.setDTR(False)
             # worst-case latency timer should be 255ms (probably <20ms)
             self._port.timeout = 0.3
             for _ in xrange(4):
@@ -867,6 +867,8 @@ def main():
         help='Serial port baud rate',
         type=arg_auto_int,
         default=os.environ.get('ESPTOOL_BAUD', ESPROM.ESP_ROM_BAUD))
+
+    parser.add_argument('--no_flow_control', help='Do not toggle DST/RST lines (this sometimes puts serial ports in broken states)', action='store_true')
 
     subparsers = parser.add_subparsers(
         dest='operation',


### PR DESCRIPTION
This adds the option to disable the use of DTR/RTS in `ESPROM.connect` with the flag `--manual_reset`. Sometimes using the DTR/RTS lines puts the serial port in a bad state, as per @chrismerck's comment in issue #82. The help string notes that using this will require people to reset their boards manually. 

Also, ignore commit `f362b9c` (the first one). I changed the naming scheme used in that one to more accurately reflect what the flag was doing. 
