### PR TITLE
port esptool to python 2/3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ GTAGS
 esptool.egg-info
 build
 dist
-
+.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 python:
   - "2.7"
+  - "3.5"
 
 script:
   - python setup.py build

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [flake8]
-ignore = E231,E221
+ignore = E231,E221,FI50,FI11,FI12,FI53,FI54,FI15,FI16,FI17
 max-line-length = 160
+

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,6 @@ from setuptools import setup
 import io
 import os
 import re
-import sys
-
-
-if sys.version_info[0] > 2:
-    raise RuntimeError("esptool.py only supports Python 2.x")
 
 
 # Example code to pull version from esptool.py with regex, taken from

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import division, print_function, unicode_literals
+
 from setuptools import setup
 import io
 import os
@@ -77,6 +79,7 @@ setup(
     ],
     setup_requires=[
         'flake8<3.0.0',
+        'flake8-future-import',
     ],
     install_requires=[
         'pyserial',


### PR DESCRIPTION
I've ported esptool to python 3.

I tried to change as little as possible, because the refactoring probably should come in a different commit. I suggest in the future that all byte strings be removed, and there is a transition to passing data around as a list of integers.

The only functional change I made (I think ;) ) was that there was a blind try/except which was hiding exceptions in the early part of the connection routine, so it now prints out the exception string.

I have tested the following things to work with both python 2.7.5 and python 3.5.1 on a nodemcu v0.9 by flashing micropython:

```
python esptool.py -p /dev/tty.wchusbserial1420 write_flash --flash_size=8M --verify 0 ~/Downloads/esp8266-20160909-v1.8.4.bin

python esptool.py -p /dev/tty.wchusbserial1420 read_mac

python esptool.py -p /dev/tty.wchusbserial1420 chip_id

python esptool.py -p /dev/tty.wchusbserial1420 flash_id

python esptool.py -p /dev/tty.wchusbserial1420 erase_flash
```

I'm not all that experienced with the other features of esptool, so I would appreciate some help in testing them.
