### PR TITLE
Resolved serial flash issues for legacy devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,6 @@ The `--before` argument allows you to specify whether the chip needs resetting i
 
 * `--before default_reset` is the default, which uses DTR & RTS serial control lines (see [Entering The Bootloader](#entering-the-bootloader)) to try and reset the chip into bootloader mode.
 * `--before no_reset` will skip any DTR/RTS control signals and just start sending a serial synchronisation command to the chip. This is useful if your chip doesn't have DTR/RTS, or for some serial interfaces (like Arduino board onboard serial) which behave differently when DTR/RTS are toggled.
-* `--before esp32r0` is a special reset sequence that can work around an automatic reset bug when using Windows with first generation ESP32 chips.
 
 #### Reset After Operation
 


### PR DESCRIPTION
Resolves issue #136 

- Attempts normal connections, then attempts legacy connections
- Improves legacy connection compatibility
- Doesn't slow down non-legacy connect time

I've tested this in Windows (in MSYS2 latest as well as as a compiled .exe with Arduino-ESP32 in Arduino - it worked equally well with both). Note that I used the latest Silicon Labs and FTDI drivers for the respective boards, without enumeration mode.

I tested against the Core Board v2 and the ESP-WROVER-KIT. In both cases the time to connect was minimal for the given board (since the Core Board requires the delay it takes longer to connect to, but since its attempt is always first the WROVER-KIT board connects quickly as normal).

The net effect is that the Core Board v2 can finally be reliably flashed now via Windows without manual intervention. This may similarly positively impact older boards without requiring extra command-line options such as `esp32r0`.
