### PR TITLE
Fix read_mac function for the ESP32

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -900,11 +900,11 @@ class ESP32ROM(ESPLoader):
 
     def read_mac(self):
         """ Read MAC from EFUSE region """
-        words = [self.read_efuse(1), self.read_efuse(2)]
+        words = [self.read_efuse(2), self.read_efuse(1)]
         bitstring = struct.pack(">II", *words)
-        bitstring = bitstring[:6]  # trim 2 byte CRC
+        bitstring = bitstring[2:8]  # trim the 2 byte CRC
         try:
-            return tuple(ord(b) for b in bitstring)  # trim 2 byte CRC
+            return tuple(ord(b) for b in bitstring)
         except TypeError:  # Python 3, bitstring elements are already bytes
             return tuple(bitstring)
 


### PR DESCRIPTION
The current read_mac function in esptool is not returning the same MAC address as: ```esp_wifi_get_mac(WIFI_IF_STA, ...)```. It's only returning the last 4 bytes of the MAC address combined with the CRC at the end.