### PR TITLE
In setup.py specify console_scripts rather than scripts (better cross…

### DIFF
--- a/espefuse.py
+++ b/espefuse.py
@@ -498,9 +498,14 @@ def _get_efuse(efuses, efuse_name):
     return [e for e in efuses if efuse_name == e.register_name][0]
 
 
-if __name__ == '__main__':
+def _main():
     try:
         main()
     except esptool.FatalError as e:
         print('\nA fatal error occurred: %s' % e)
         sys.exit(2)
+
+
+if __name__ == '__main__':
+    _main()
+

--- a/espsecure.py
+++ b/espsecure.py
@@ -371,9 +371,13 @@ def main():
     operation_func(args)
 
 
-if __name__ == '__main__':
+def _main():
     try:
         main()
     except esptool.FatalError as e:
         print('\nA fatal error occurred: %s' % e)
         sys.exit(2)
+
+
+if __name__ == '__main__':
+    _main()

--- a/esptool.py
+++ b/esptool.py
@@ -2289,9 +2289,13 @@ V8ZPp6X82ggwJrsl96cptxlIzDaUwmfz/kcmucr4Y7ba3SRrKc0mTJzssSXkDCPxACddCSNp96Lr3qdK
 """)))
 
 
-if __name__ == '__main__':
+def _main():
     try:
         main()
     except FatalError as e:
         print('\nA fatal error occurred: %s' % e)
         sys.exit(2)
+
+
+if __name__ == '__main__':
+    _main()

--- a/setup.py
+++ b/setup.py
@@ -90,9 +90,11 @@ setup(
         'pyaes',
         'ecdsa',
     ],
-    scripts=[
-        'esptool.py',
-        'espsecure.py',
-        'espefuse.py',
-    ],
+    entry_points={
+        'console_scripts': [
+            'esptool.py=esptool:_main',
+            'espsecure.py=espsecure:_main',
+            'espefuse.py=espefuse:_main',
+        ],
+    },
 )


### PR DESCRIPTION
…-platform compability). See https://packaging.python.org/distributing/#scripts. Fixes https://github.com/espressif/esptool/issues/181

Tested on Windows

The principal benefit is that on Windows the application will be installed as `esptool.exe` rather than `esptool.py`