### PR TITLE
Display usage information when no arguments are provided

### DIFF
--- a/espefuse.py
+++ b/espefuse.py
@@ -509,6 +509,10 @@ def main():
 
     args = parser.parse_args()
     print('espefuse.py v%s' % esptool.__version__)
+    if args.operation is None:
+        parser.print_help()
+        parser.exit(1)
+
     # each 'operation' is a module-level function of the same name
     operation_func = globals()[args.operation]
 

--- a/espsecure.py
+++ b/espsecure.py
@@ -368,6 +368,10 @@ def main():
 
     args = parser.parse_args()
     print('espsecure.py v%s' % esptool.__version__)
+    if args.operation is None:
+        parser.print_help()
+        parser.exit(1)
+
     # each 'operation' is a module-level function of the same name
     operation_func = globals()[args.operation]
     operation_func(args)


### PR DESCRIPTION
Previously a traceback was shown instead.

Fixes https://github.com/espressif/esptool/issues/211