### PR TITLE
Add missing testing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,12 +103,12 @@ setup(
     tests_require=[
         'flake8>=3.2.0',
         'flake8-future-import',
+        'pyelftools',
     ],
     install_requires=[
         'pyserial>=2.5',
         'pyaes',
         'ecdsa',
-        'pyelftools',
     ],
     scripts=scripts,
     entry_points=entry_points,

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         'pyserial>=2.5',
         'pyaes',
         'ecdsa',
+        'pyelftools',
     ],
     scripts=scripts,
     entry_points=entry_points,


### PR DESCRIPTION
I was missing this package in order to run all the tests.  `pyelftools` is needed by `test/test_imagegen.py`