### PR TITLE
Change shebang reference to 'python' to be 'python2' instead

### DIFF
--- a/ecdsa/ecdsa.py
+++ b/ecdsa/ecdsa.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
 Implementation of Elliptic-Curve Digital Signatures.

--- a/ecdsa/ellipticcurve.py
+++ b/ecdsa/ellipticcurve.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Implementation of elliptic curves, for cryptographic applications.
 #

--- a/ecdsa/numbertheory.py
+++ b/ecdsa/numbertheory.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Provide some simple capabilities from number theory.
 #

--- a/espefuse.py
+++ b/espefuse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # ESP32 efuse get/set utility
 # https://github.com/themadinventor/esptool
 #

--- a/espsecure.py
+++ b/espsecure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # ESP32 secure boot utility
 # https://github.com/themadinventor/esptool
 #

--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # ESP8266 & ESP32 ROM Bootloader Utility
 # Copyright (C) 2014-2016 Fredrik Ahlberg, Angus Gratton, Espressif Systems (Shanghai) PTE LTD, other contributors as noted.

--- a/flasher_stub/compare_stubs.py
+++ b/flasher_stub/compare_stubs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 
 # Compare the esptool stub loaders to freshly built ones

--- a/test/test_esptool.py
+++ b/test/test_esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
 esptool.py "unit" tests (really integration tests). Uses a device connected to the serial port.
 

--- a/test/test_imagegen.py
+++ b/test/test_imagegen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os.path
 import subprocess
 import sys


### PR DESCRIPTION
# Description of change

PEP-394 recommends that scripts only use the 'python' command in the shebang if they are source compatible with both Python2 and Python3. Over time environments will migrate towards pointing 'python' at 'python3', meaning scripts that are only python2 compatible will likely fail. esptool is included in this list.

Most recently, the popular Homebrew package manager for macOS made this change: https://brew.sh/2018/01/19/homebrew-1.5.0/, which broke my workflow, so thought it best to help everyone out.

There is no effect for those whose python command still points to python2.

# I have tested this change with the following hardware & software combinations:

macOS 10.13, ESP-WROVER-KIT, ESP32

(Operating system(s), development board name(s), ESP8266 and/or ESP32.)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

./test_imagegen.py
Running image generation tests...
.........
----------------------------------------------------------------------
Ran 9 tests in 1.719s

OK

./test_esptool.py /dev/tty.usbserial-14101 esp32 230400
Running esptool.py tests...
........................................
----------------------------------------------------------------------
Ran 40 tests in 442.823s

OK
