### PR TITLE
esptool: Add new argument "--no-sync" to skip sync and initial baud

### DIFF
--- a/espefuse.py
+++ b/espefuse.py
@@ -554,8 +554,18 @@ def hexify(bitstring, separator):
     return separator.join(("%02x" % b) for b in as_bytes)
 
 
+def arg_auto_int(x):
+    return int(x, 0)
+
+
 def main():
     parser = argparse.ArgumentParser(description='espefuse.py v%s - ESP32 efuse get/set tool' % esptool.__version__, prog='espefuse')
+
+    parser.add_argument(
+        '--baud', '-b',
+        help='Serial port baud rate used when flashing/reading',
+        type=arg_auto_int,
+        default=os.environ.get('ESPTOOL_BAUD', esptool.ESPLoader.ESP_ROM_BAUD))
 
     parser.add_argument(
         '--port', '-p',
@@ -623,7 +633,7 @@ def main():
     # each 'operation' is a module-level function of the same name
     operation_func = globals()[args.operation]
 
-    esp = esptool.ESP32ROM(args.port)
+    esp = esptool.ESP32ROM(args.port, baud=args.baud)
     esp.connect(args.before)
 
     # dict mapping register name to its efuse object

--- a/espefuse.py
+++ b/espefuse.py
@@ -565,7 +565,7 @@ def main():
     parser.add_argument(
         '--before',
         help='What to do before connecting to the chip',
-        choices=['default_reset', 'no_reset', 'esp32r1'],
+        choices=['default_reset', 'no_reset', 'esp32r1', 'no_reset_no_sync'],
         default='default_reset')
 
     parser.add_argument('--do-not-confirm',

--- a/esptool.py
+++ b/esptool.py
@@ -365,6 +365,11 @@ class ESPLoader(object):
         # Details: https://github.com/espressif/esptool/issues/136
         last_error = None
 
+        # If we're doing no_sync, we're likely communicating as a pass through
+        # with an intermediate device to the ESP32
+        if mode == "no_reset_no_sync":
+            return last_error
+
         # issue reset-to-bootloader:
         # RTS = either CH_PD/EN or nRESET (both active low = chip in reset
         # DTR = GPIO0 (active low = boot to flasher)
@@ -2158,7 +2163,7 @@ def main():
     parser.add_argument(
         '--before',
         help='What to do before connecting to the chip',
-        choices=['default_reset', 'no_reset'],
+        choices=['default_reset', 'no_reset', 'no_reset_no_sync'],
         default=os.environ.get('ESPTOOL_BEFORE', 'default_reset'))
 
     parser.add_argument(
@@ -2354,7 +2359,11 @@ def main():
         operation_args = inspect.getfullargspec(operation_func).args
 
     if operation_args[0] == 'esp':  # operation function takes an ESPLoader connection object
-        initial_baud = min(ESPLoader.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
+        if args.before != "no_reset_no_sync":
+            initial_baud = min(ESPLoader.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
+        else:
+            initial_baud = args.baud
+
         if args.chip == 'auto':
             esp = ESPLoader.detect_chip(args.port, initial_baud, args.before, args.trace)
         else:


### PR DESCRIPTION
We have a board designed which has the UART to the ESP32 as a passthrough from
another microcontroller.  As such, it's easier to send the sync sequence and
change the baud rate on the microcontroller side of things than to pass this
change through from the PC.  Adding the --no-sync option allows the intermediate
microcontroller to run the sync sequence and to set the appropriate baud rate
on the ESP32 side of things.  For this use case, we need to avoid sending the
change buad rate sequence (the PC baud rate is not necessarily the same as
the microcontroller <-> ESP32) and avoid sending the sync sequence.

Signed-off-by: Tim Nordell <tim.nordell@nimbelink.com>
