### PR TITLE
Improve usability (default COM port) when programming

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2218,6 +2218,7 @@ def version(args):
 # End of operations functions
 #
 
+
 def all_serial_ports():
     import serial.tools.list_ports as list_ports
 

--- a/esptool.py
+++ b/esptool.py
@@ -31,6 +31,7 @@ import sys
 import time
 import zlib
 import string
+import serial.tools.list_ports as list_ports
 
 import serial
 
@@ -2219,16 +2220,6 @@ def version(args):
 #
 
 
-def all_serial_ports():
-    import serial.tools.list_ports as list_ports
-
-    result = []
-    for port in list_ports.comports():
-        result.append(port.device)
-    result.sort()
-    return result
-
-
 def main():
     parser = argparse.ArgumentParser(description='esptool.py v%s - ESP8266 ROM Bootloader Utility' % __version__, prog='esptool')
 
@@ -2448,10 +2439,8 @@ def main():
 
     if operation_args[0] == 'esp':  # operation function takes an ESPLoader connection object
         initial_baud = min(ESPLoader.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
-        ser_list = all_serial_ports() if args.port is None else [args.port]
-        ser_attempts = 0
+        ser_list = sorted(ports.device for ports in list_ports.comports())
         for each_port in reversed(ser_list):
-            ser_attempts += 1
             if args.port is None:
                 print("Trying %s ... " % each_port)
             try:

--- a/esptool.py
+++ b/esptool.py
@@ -29,7 +29,6 @@ import shlex
 import struct
 import sys
 import time
-
 import zlib
 import string
 

--- a/esptool.py
+++ b/esptool.py
@@ -433,7 +433,6 @@ class ESPLoader(object):
         last_error = None
 
         try:
-            #for _ in range(10):
             for _ in range(3):
                 last_error = self._connect_attempt(mode=mode, esp32r0_delay=False)
                 if last_error is None:
@@ -2243,7 +2242,7 @@ def all_serial_ports():
             s.close()
             result.append(port)
         except (OSError, serial.SerialException):
-             pass
+            pass
     return result
 
 
@@ -2466,7 +2465,7 @@ def main():
 
     if operation_args[0] == 'esp':  # operation function takes an ESPLoader connection object
         initial_baud = min(ESPLoader.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
-        if args.port == ESPLoader.DEFAULT_PORT: # if port is not specified, try to auto find it
+        if args.port == ESPLoader.DEFAULT_PORT:  # if port is not specified, try to auto find it
             ser_list = all_serial_ports()  # Grab the list of available ports
             print("Port not specified! \t Using port auto find...")
             print(ser_list)

--- a/esptool.py
+++ b/esptool.py
@@ -30,8 +30,6 @@ import struct
 import sys
 import time
 
-import glob
-
 import zlib
 import string
 
@@ -433,7 +431,7 @@ class ESPLoader(object):
         last_error = None
 
         try:
-            for _ in range(3):
+            for _ in range(7):
                 last_error = self._connect_attempt(mode=mode, esp32r0_delay=False)
                 if last_error is None:
                     return
@@ -2218,13 +2216,10 @@ def version(args):
 
 
 def all_serial_ports():
-    """Returns all open serial ports as a list
-
-    Will check the environment your running on, and return a list of all available ports.
-
-    Returns:
-        A list of all available ports e.g. COM1, COM11, COM12....
     """
+    https://stackoverflow.com/questions/12090503/listing-available-com-ports-with-python
+    """
+    import glob
 
     if sys.platform.startswith('win'):
         ports = ['COM%s' % (i + 1) for i in range(256)]
@@ -2243,6 +2238,16 @@ def all_serial_ports():
             result.append(port)
         except (OSError, serial.SerialException):
             pass
+    return result
+
+
+def all_serial_ports_2():
+    import serial.tools.list_ports as list_ports
+
+    result = []
+    for port in list_ports.comports():
+        result.append(port.device)
+    result.sort()
     return result
 
 
@@ -2465,8 +2470,7 @@ def main():
 
     if operation_args[0] == 'esp':  # operation function takes an ESPLoader connection object
         initial_baud = min(ESPLoader.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
-
-        ser_list = all_serial_ports() if args.port is None else [args.port]
+        ser_list = all_serial_ports_2() if args.port is None else [args.port]
         ser_attempts = 0
         for each_port in reversed(ser_list):
             ser_attempts += 1


### PR DESCRIPTION
# Description of change

### Added 'Auto COM Port' as the default action when no port is specified.
The default COM port is `DEFAULT_PORT = "/dev/ttyUSB0"` which is incorrect for Windows machines and some users (less technical) have difficulty finding the COM port (often it is a dual port).
If no port is parsed in the CLI, then all available ports are discovered and attempted to connect the ESP device. The first successful one is used thereafter. If the port is passed through the CLI then the normal operation takes place.

### Reduced the number of connection attempts from 10 to 3 
Auto COM finder could take ages if it's 10, also if no connection after 3 attempts its unlikely to succeed.

### Print the MAC address when programming

# I have tested this change with the following hardware & software combinations:

Windows 7, Python3.6, ESP32-WROOM

Results:
`esptool.py v2.4.0-dev
Port not specified!      Using port auto find...
['COM1', 'COM15', 'COM16']
Trying COM1
Connecting........_____....._____....._____
Trying COM15
Connecting........_____....._____....._____
Trying COM16
Connecting.......
Chip is ESP32D0WDQ6 (revision 1)
Features: WiFi, BT, Dual Core`