### PR TITLE
Print MAC before programming

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2447,6 +2447,8 @@ def main():
 
         print("Features: %s" % ", ".join(esp.get_chip_features()))
 
+        read_mac(esp, args)
+
         if not args.no_stub:
             esp = esp.run_stub()
 


### PR DESCRIPTION
# Description of change

Print the MAC address when programming - This is useful when you need to keep track of multiple modules being flashed.

# I have tested this change with the following hardware & software combinations:

Windows 7, Python3.6, ESP32-WROOM
