### PR TITLE
Fix for non-closure of serial ports when invoking main()

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2492,6 +2492,8 @@ def main():
 
     else:
         operation_func(args)
+    
+    esp._port.close()
 
 
 def expand_file_arguments():

--- a/esptool.py
+++ b/esptool.py
@@ -2489,12 +2489,10 @@ def main():
             print('Staying in bootloader.')
             if esp.IS_STUB:
                 esp.soft_reset(True)  # exit stub back to ROM loader
-
+		esp._port.close()
     else:
         operation_func(args)
     
-    esp._port.close()
-
 
 def expand_file_arguments():
     """ Any argument starting with "@" gets replaced with all values read from a text file.

--- a/esptool.py
+++ b/esptool.py
@@ -2489,7 +2489,7 @@ def main():
             print('Staying in bootloader.')
             if esp.IS_STUB:
                 esp.soft_reset(True)  # exit stub back to ROM loader
-		esp._port.close()
+        esp._port.close()
     else:
         operation_func(args)
     

--- a/esptool.py
+++ b/esptool.py
@@ -382,6 +382,11 @@ class ESPLoader(object):
         # Details: https://github.com/espressif/esptool/issues/136
         last_error = None
 
+        # If we're doing no_sync, we're likely communicating as a pass through
+        # with an intermediate device to the ESP32
+        if mode == "no_reset_no_sync":
+            return last_error
+
         # issue reset-to-bootloader:
         # RTS = either CH_PD/EN or nRESET (both active low = chip in reset
         # DTR = GPIO0 (active low = boot to flasher)
@@ -2236,7 +2241,7 @@ def main():
     parser.add_argument(
         '--before',
         help='What to do before connecting to the chip',
-        choices=['default_reset', 'no_reset'],
+        choices=['default_reset', 'no_reset', 'no_reset_no_sync'],
         default=os.environ.get('ESPTOOL_BEFORE', 'default_reset'))
 
     parser.add_argument(
@@ -2432,7 +2437,11 @@ def main():
         operation_args = inspect.getfullargspec(operation_func).args
 
     if operation_args[0] == 'esp':  # operation function takes an ESPLoader connection object
-        initial_baud = min(ESPLoader.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
+        if args.before != "no_reset_no_sync":
+            initial_baud = min(ESPLoader.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
+        else:
+            initial_baud = args.baud
+
         if args.chip == 'auto':
             esp = ESPLoader.detect_chip(args.port, initial_baud, args.before, args.trace)
         else:
@@ -2446,6 +2455,8 @@ def main():
         print("Chip is %s" % (esp.get_chip_description()))
 
         print("Features: %s" % ", ".join(esp.get_chip_features()))
+
+        read_mac(esp, args)
 
         if not args.no_stub:
             esp = esp.run_stub()
@@ -2489,10 +2500,12 @@ def main():
             print('Staying in bootloader.')
             if esp.IS_STUB:
                 esp.soft_reset(True)  # exit stub back to ROM loader
+
         esp._port.close()
+
     else:
         operation_func(args)
-    
+
 
 def expand_file_arguments():
     """ Any argument starting with "@" gets replaced with all values read from a text file.


### PR DESCRIPTION
(Please delete any lines which don't apply)

# Description of change

This adds a single line ensuring that the port is closed explicitly on leaving the main() function. This is otherwise impossible to achieve from outside the main function since the 'esp' reference is local to main() so cannot be introspected to close the port.

# This change fixes the following bug(s):

(Please put issue URLs or #number-of-issue here.)

https://github.com/espressif/esptool/issues/313

# I have tested this change with the following hardware & software combinations:

(Operating system(s), development board name(s), ESP8266 and/or ESP32.)

Windows 10, NodeMCU-M with CH340

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

Integration tests ran identically on Ubuntu Bionic with or without the one-line change, although it had two failures at high baud rates.

See this log for details...

```
(venv) cefn-bionic-thinkpad:test$ ./test_esptool.py /dev/ttyUSB0 esp8266 115200 
Running esptool.py tests...
..............E
Stdout:
**************************************************
Running /home/cefn/Developer/git/esptool/test/venv/bin/python /home/cefn/Developer/git/esptool/test/../esptool.py --chip esp8266 --port /dev/ttyUSB0 --baud 115200 write_flash 0x10000 images/one_mb_zeroes.bin...
b'esptool.py v2.4.0-dev\nConnecting....\nChip is ESP8285\nFeatures: WiFi, Embedded Flash\nUploading stub...\nRunning stub...\nStub running...\nConfiguring flash size...\nAuto-detected Flash size: 1MB\n\nA fatal error occurred: File images/one_mb_zeroes.bin (length 1048576) at offset 65536 will not fit in 1048576 bytes of flash. Use --flash-size argument, or change flashing address.\n'
.E
Stdout:
**************************************************
Running /home/cefn/Developer/git/esptool/test/venv/bin/python /home/cefn/Developer/git/esptool/test/../esptool.py --chip esp8266 --port /dev/ttyUSB0 --baud 921600 write_flash 0x0 images/fifty_kb.bin...
b'esptool.py v2.4.0-dev\nConnecting....\nChip is ESP8285\nFeatures: WiFi, Embedded Flash\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 921600\nChanged.\nConfiguring flash size...\n\nA fatal error occurred: Invalid head of packet (0xE0)\n'
........................
======================================================================
ERROR: test_compressible_file (__main__.TestFlashing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./test_esptool.py", line 204, in test_compressible_file
    self.run_esptool("write_flash 0x10000 images/one_mb_zeroes.bin")
  File "./test_esptool.py", line 61, in run_esptool
    raise e
  File "./test_esptool.py", line 56, in run_esptool
    output = subprocess.check_output([str(s) for s in cmd], cwd=TEST_DIR, stderr=subprocess.STDOUT)
  File "/usr/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/home/cefn/Developer/git/esptool/test/venv/bin/python', '/home/cefn/Developer/git/esptool/test/../esptool.py', '--chip', 'esp8266', '--port', '/dev/ttyUSB0', '--baud', '115200', 'write_flash', '0x10000', 'images/one_mb_zeroes.bin']' returned non-zero exit status 2.

Stdout:
**************************************************
Running /home/cefn/Developer/git/esptool/test/venv/bin/python /home/cefn/Developer/git/esptool/test/../esptool.py --chip esp8266 --port /dev/ttyUSB0 --baud 115200 write_flash 0x10000 images/one_mb_zeroes.bin...
b'esptool.py v2.4.0-dev\nConnecting....\nChip is ESP8285\nFeatures: WiFi, Embedded Flash\nUploading stub...\nRunning stub...\nStub running...\nConfiguring flash size...\nAuto-detected Flash size: 1MB\n\nA fatal error occurred: File images/one_mb_zeroes.bin (length 1048576) at offset 65536 will not fit in 1048576 bytes of flash. Use --flash-size argument, or change flashing address.\n'

======================================================================
ERROR: test_highspeed_flash (__main__.TestFlashing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./test_esptool.py", line 124, in test_highspeed_flash
    self.run_esptool("write_flash 0x0 images/fifty_kb.bin", baud=921600)
  File "./test_esptool.py", line 61, in run_esptool
    raise e
  File "./test_esptool.py", line 56, in run_esptool
    output = subprocess.check_output([str(s) for s in cmd], cwd=TEST_DIR, stderr=subprocess.STDOUT)
  File "/usr/lib/python3.6/subprocess.py", line 336, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/home/cefn/Developer/git/esptool/test/venv/bin/python', '/home/cefn/Developer/git/esptool/test/../esptool.py', '--chip', 'esp8266', '--port', '/dev/ttyUSB0', '--baud', '921600', 'write_flash', '0x0', 'images/fifty_kb.bin']' returned non-zero exit status 2.

Stdout:
**************************************************
Running /home/cefn/Developer/git/esptool/test/venv/bin/python /home/cefn/Developer/git/esptool/test/../esptool.py --chip esp8266 --port /dev/ttyUSB0 --baud 921600 write_flash 0x0 images/fifty_kb.bin...
b'esptool.py v2.4.0-dev\nConnecting....\nChip is ESP8285\nFeatures: WiFi, Embedded Flash\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 921600\nChanged.\nConfiguring flash size...\n\nA fatal error occurred: Invalid head of packet (0xE0)\n'

----------------------------------------------------------------------
Ran 41 tests in 646.536s

FAILED (errors=2)

```
