### PR TITLE
Close serial port before exit from main()

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2490,6 +2490,8 @@ def main():
             if esp.IS_STUB:
                 esp.soft_reset(True)  # exit stub back to ROM loader
 
+        esp._port.close()
+
     else:
         operation_func(args)
 


### PR DESCRIPTION
Addresses the issue detailed at https://github.com/espressif/esptool/issues/313 and has the close call inside the proper if block.