### PR TITLE
Add `esp` variable assigment

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2511,6 +2511,7 @@ def main():
             print("Found %d serial ports" % len(ser_list))
         else:
             ser_list = [args.port]
+        esp = None
         for each_port in reversed(ser_list):
             print("Serial port %s" % each_port)
             try:


### PR DESCRIPTION
# Description of change

Assign `None` to `esp` variable in `main()` function. 
`esp` variable was not assigned before the loop, and in case if there were no serial ports detected, the following exception was raised:

```python
esptool.py v2.4.1
Found 0 serial ports
Traceback (most recent call last):
  File "c:\dev\anaconda3\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\dev\anaconda3\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Dev\Anaconda3\Scripts\esptool.exe\__main__.py", line 9, in <module>
  File "c:\dev\anaconda3\lib\site-packages\esptool.py", line 2814, in _main
    main()
  File "c:\dev\anaconda3\lib\site-packages\esptool.py", line 2529, in main
    if esp is None:
UnboundLocalError: local variable 'esp' referenced before assignment
```
