### PR TITLE
add argument to erase flash before flashing

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2048,6 +2048,9 @@ def write_flash(esp, args):
                              % (argfile.name, argfile.tell(), address, flash_end))
         argfile.seek(0)
 
+    if args.erase_all:
+        erase_flash(esp, args)
+
     for address, argfile in args.addr_filename:
         if args.no_stub:
             print('Erasing flash...')
@@ -2401,15 +2404,18 @@ def main():
                             default=os.environ.get('ESPTOOL_FS', 'detect' if auto_detect else '1MB'))
         add_spi_connection_arg(parent)
 
-    parser_write_flash = subparsers.add_parser(
-        'write_flash',
-        help='Write a binary blob to flash')
+    parser_write_flash = subparsers.add_parser('write_flash', help='Write a binary blob to flash')
     parser_write_flash.add_argument('addr_filename', metavar='<address> <filename>', help='Address followed by binary filename, separated by space',
                                     action=AddrFilenamePairAction)
+    parser_write_flash.add_argument('--erase_all', '-e',
+                                    help='Erase all regions of flash (not just write areas) before programming',
+                                    action="store_true")
+
     add_spi_flash_subparsers(parser_write_flash, is_elf2image=False)
     parser_write_flash.add_argument('--no-progress', '-p', help='Suppress progress output', action="store_true")
     parser_write_flash.add_argument('--verify', help='Verify just-written data on flash ' +
                                     '(mostly superfluous, data is read back during flashing)', action='store_true')
+
     compress_args = parser_write_flash.add_mutually_exclusive_group(required=False)
     compress_args.add_argument('--compress', '-z', help='Compress data in transfer (default unless --no-stub is specified)',action="store_true", default=None)
     compress_args.add_argument('--no-compress', '-u', help='Disable data compression during transfer (default if --no-stub is specified)',action="store_true")


### PR DESCRIPTION
# Description of change

Sometimes we want to erase the whole chip because we use some partitions for other data (like OTA) which is not overwritten when flashed with new firmware. Currently, this makes this a 2 stage process (erase_flash ... then write_flash) - This change is intended to make this a one stage command.

As this is a new argument please advise if you prefer another format.

# I have tested this change with the following hardware & software combinations:

ESP32, Windows 7, Python 3.6

