### PR TITLE
Fix too-broad-exception as discussed in PEP8

### DIFF
--- a/pyaes/aes.py
+++ b/pyaes/aes.py
@@ -74,7 +74,7 @@ def _concat_list(a, b):
 # Python 3 compatibility
 try:
     xrange
-except Exception:
+except NameError:
     xrange = range
 
     # Python 3 supports bytes, which is already an array of integers

--- a/pyaes/util.py
+++ b/pyaes/util.py
@@ -34,8 +34,7 @@ def _get_byte(c):
 
 try:
     xrange
-except:
-
+except NameError:
     def to_bufferable(binary):
         if isinstance(binary, bytes):
             return binary


### PR DESCRIPTION
(Please delete any lines which don't apply)

# Description of change

# This change fixes the following bug(s):

(Please put issue URLs or #number-of-issue here.)

# I have tested this change with the following hardware & software combinations:

(Operating system(s), development board name(s), ESP8266 and/or ESP32.)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

(Details here: https://github.com/espressif/esptool/blob/master/CONTRIBUTING.md#automated-integration-tests )
