### PR TITLE
Travis CI: Drop EOLed Python 3.4 and add Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: false
+dist: xenial  # required for Python >= 3.7
 env:
   # Downloadable toolchains & SDKs for esp8266 & esp32
   #
@@ -28,12 +28,12 @@ env:
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then ./.travis_setup_build_env.sh; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then ./.travis_setup_build_env.sh; fi
 
 script:
   # test python components (fast)
@@ -51,6 +51,6 @@ script:
   - ( cd / && espefuse.py --help )
   - ( cd / && espsecure.py --help )
   # build stub (Python 3 only)
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then make -C flasher_stub V=1; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then make -C flasher_stub V=1; fi
   # check the just-built stub matches the one in esptool.py
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then cd flasher_stub && python ./compare_stubs.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.7 ]]; then cd flasher_stub && python ./compare_stubs.py; fi


### PR DESCRIPTION
Python 3.4 has reached its end of life. https://devguide.python.org/devcycle/#end-of-life-branches

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

(Please delete any lines which don't apply)

# Description of change

# This change fixes the following bug(s):

(Please put issue URLs or #number-of-issue here.)

# I have tested this change with the following hardware & software combinations:

(Operating system(s), development board name(s), ESP8266 and/or ESP32.)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

(Details here: https://github.com/espressif/esptool/blob/master/CONTRIBUTING.md#automated-integration-tests )
