### PR TITLE
Actually run flake8 on the codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
   - python test/test_imagegen.py
   - python test/test_espsecure.py
   - pip install flake8 flake8-future-import  # matches tests_require in setup.py, a bit hacky
+  - flake8 .
   - python setup.py flake8
   - python setup.py install
   - ( cd / && esptool.py --help )  # check the installed versions can run


### PR DESCRIPTION
Perhaps run [__python/black__](https://github.com/python/black) on the codebase and then fix the other flake8 issues by hand.

(Please delete any lines which don't apply)

# Description of change

# This change fixes the following bug(s):

(Please put issue URLs or #number-of-issue here.)

# I have tested this change with the following hardware & software combinations:

(Operating system(s), development board name(s), ESP8266 and/or ESP32.)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

(Details here: https://github.com/espressif/esptool/blob/master/CONTRIBUTING.md#automated-integration-tests )
