### PR TITLE
Made Arduino IDE scroll during upload

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -80,6 +80,7 @@ if sys.stdout.isatty():
 else:
     CR = '\n'
 
+
 def timeout_per_mb(seconds_per_mb, size_bytes):
     """ Scales timeouts which are size-specific """
     result = seconds_per_mb * (size_bytes / 1e6)
@@ -2369,8 +2370,8 @@ def dump_mem(esp, args):
             d = esp.read_reg(args.address + (i * 4))
             f.write(struct.pack(b'<I', d))
             if f.tell() % 1024 == 0:
-                print(CR +'%d bytes read... (%d %%)' % (f.tell(),
-                                                        f.tell() * 100 // args.size),
+                print(CR + '%d bytes read... (%d %%)' % (f.tell(),
+                                                         f.tell() * 100 // args.size),
                       end=' ')
             sys.stdout.flush()
     print('Done!')

--- a/esptool.py
+++ b/esptool.py
@@ -75,6 +75,10 @@ ERASE_REGION_TIMEOUT_PER_MB = 30      # timeout (per megabyte) for erasing a reg
 MEM_END_ROM_TIMEOUT = 0.05            # special short timeout for ESP_MEM_END, as it may never respond
 DEFAULT_SERIAL_WRITE_TIMEOUT = 10     # timeout for serial port write
 
+if sys.stdout.isatty():
+    CR = '\r'
+else:
+    CR = '\n'
 
 def timeout_per_mb(seconds_per_mb, size_bytes):
     """ Scales timeouts which are size-specific """
@@ -2365,8 +2369,8 @@ def dump_mem(esp, args):
             d = esp.read_reg(args.address + (i * 4))
             f.write(struct.pack(b'<I', d))
             if f.tell() % 1024 == 0:
-                print('\r%d bytes read... (%d %%)' % (f.tell(),
-                                                      f.tell() * 100 // args.size),
+                print(CR +'%d bytes read... (%d %%)' % (f.tell(),
+                                                        f.tell() * 100 // args.size),
                       end=' ')
             sys.stdout.flush()
     print('Done!')
@@ -2503,7 +2507,7 @@ def write_flash(esp, args):
         written = 0
         t = time.time()
         while len(image) > 0:
-            print('\rWriting at 0x%08x... (%d %%)' % (address + seq * esp.FLASH_WRITE_SIZE, 100 * (seq + 1) // blocks), end='')
+            print(CR + 'Writing at 0x%08x... (%d %%)' % (address + seq * esp.FLASH_WRITE_SIZE, 100 * (seq + 1) // blocks), end='')
             sys.stdout.flush()
             block = image[0:esp.FLASH_WRITE_SIZE]
             if args.compress:
@@ -2523,11 +2527,11 @@ def write_flash(esp, args):
         if args.compress:
             if t > 0.0:
                 speed_msg = " (effective %.1f kbit/s)" % (uncsize / t * 8 / 1000)
-            print('\rWrote %d bytes (%d compressed) at 0x%08x in %.1f seconds%s...' % (uncsize, written, address, t, speed_msg))
+            print(CR + 'Wrote %d bytes (%d compressed) at 0x%08x in %.1f seconds%s...' % (uncsize, written, address, t, speed_msg))
         else:
             if t > 0.0:
                 speed_msg = " (%.1f kbit/s)" % (written / t * 8 / 1000)
-            print('\rWrote %d bytes at 0x%08x in %.1f seconds%s...' % (written, address, t, speed_msg))
+            print(CR + 'Wrote %d bytes at 0x%08x in %.1f seconds%s...' % (written, address, t, speed_msg))
 
         if not args.encrypt:
             try:
@@ -2690,7 +2694,7 @@ def read_flash(esp, args):
     t = time.time()
     data = esp.read_flash(args.address, args.size, flash_progress)
     t = time.time() - t
-    print('\rRead %d bytes at 0x%x in %.1f seconds (%.1f kbit/s)...'
+    print(CR + 'Read %d bytes at 0x%x in %.1f seconds (%.1f kbit/s)...'
           % (len(data), args.address, t, len(data) / t * 8 / 1000))
     with open(args.filename, 'wb') as f:
         f.write(data)


### PR DESCRIPTION
# Description of change

When esptool is run from the Arduino IDE, the output window doesn't
scroll because of the \rs used to make the console update status on a
single line.

To avoid this, don't attempt to output everything on a single line when
scripted (i.e. not running on a TTY) by replacing \r with \n.

See https://github.com/esp8266/Arduino/pull/6765 for some discussion.

# I have tested this change with the following hardware & software combinations:

ESP8266 Arduino IDE under Linux with WeMos D1 Mini (clone?)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:
** The two failures at 921k baud are expected and a known problem with my board, a WeMos D1 Mini, so can be ignored. ** 

earle@server:~/src/esptool/test$ ./test_esptool.py /dev/ttyUSB0 esp8266 230400
Running esptool.py tests...
.......sss..........s..E
Stdout:
**************************************************
Running /usr/bin/python /home/earle/src/esptool/test/../esptool.py --chip esp8266 --port /dev/ttyUSB0 --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v2.9-dev
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP8266EX
Features: WiFi
Crystal is 26MHz
MAC: 60:01:94:23:b4:a6
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

A fatal error occurred: Invalid head of packet (0xE0)

........................
======================================================================
ERROR: test_highspeed_flash (__main__.TestFlashing)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./test_esptool.py", line 226, in test_highspeed_flash
    self.run_esptool("write_flash 0x0 images/fifty_kb.bin", baud=921600)
  File "./test_esptool.py", line 85, in run_esptool
    raise e
CalledProcessError: Command '['/usr/bin/python', '/home/earle/src/esptool/test/../esptool.py', '--chip', 'esp8266', '--port', '/dev/ttyUSB0', '--baud', '921600', 'write_flash', '0x0', 'images/fifty_kb.bin']' returned non-zero exit status 2

Stdout:
**************************************************
Running /usr/bin/python /home/earle/src/esptool/test/../esptool.py --chip esp8266 --port /dev/ttyUSB0 --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v2.9-dev
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP8266EX
Features: WiFi
Crystal is 26MHz
MAC: 60:01:94:23:b4:a6
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

A fatal error occurred: Invalid head of packet (0xE0)


----------------------------------------------------------------------
Ran 48 tests in 439.226s

FAILED (errors=1, skipped=4)

