### PR TITLE
Guard STATUS_QIE_BIT definition to ESP32/ESP32S2

### DIFF
--- a/flasher_stub/stub_write_flash.c
+++ b/flasher_stub/stub_write_flash.c
@@ -50,7 +50,9 @@ static struct {
 
 /* SPI status bits */
 static const uint32_t STATUS_WIP_BIT = (1 << 0);
+#if defined(ESP32) || defined(ESP32S2)
 static const uint32_t STATUS_QIE_BIT = (1 << 9);  /* Quad Enable */
+#endif
 
 bool is_in_flash_mode(void)
 {


### PR DESCRIPTION
Only used there, which causes a "defined but not used"
(-Wunused-const-variable) compiler error in newer versions of GCC.

Rather than disable what is otherwise a useful compiler warning, make
the definition conditional to the ESP32s.

See #499 for context.