### PR TITLE
Fix TypeError on writing v2 signing key

### DIFF
--- a/espsecure.py
+++ b/espsecure.py
@@ -166,7 +166,7 @@ def generate_signing_key(args):
             format=serialization.PrivateFormat.TraditionalOpenSSL,
             encryption_algorithm=serialization.NoEncryption()
         ).decode()
-        with open(args.keyfile, "wb") as f:
+        with open(args.keyfile, "w") as f:
             f.write(private_key)
         print("RSA 3072 private key in PEM format written to %s" % args.keyfile)
 


### PR DESCRIPTION
# Description of change
When trying to create a signing key version 2 you will get the following stacktrace:
```
espsecure.py v3.0-dev
Traceback (most recent call last):
  File "/opt/esp/idf/components/esptool_py/esptool/espsecure.py", line 735, in <module>
    _main()
  File "/opt/esp/idf/components/esptool_py/esptool/espsecure.py", line 728, in _main
    main()
  File "/opt/esp/idf/components/esptool_py/esptool/espsecure.py", line 723, in main
    operation_func(args)
  File "/opt/esp/idf/components/esptool_py/esptool/espsecure.py", line 170, in generate_signing_key
    f.write(private_key)
TypeError: a bytes-like object is required, not 'str'
```
This was fixed by changing the file open attributes to be not binary ("w" instead of "wb").

# This change fixes the following bug(s):
TypeError on writing a v2 signing key 

# I have tested this change with the following hardware & software combinations:
latest docker image
