### PR TITLE
Feature/serial port search espefuse (ESPTOOL-163)

### DIFF
--- a/espefuse.py
+++ b/espefuse.py
@@ -998,8 +998,8 @@ def main():
     operation_func = globals()[args.operation]
 
     # Connect to a device at given port, or iterate through ports if none provided
-    args.chip = 'auto' # set chip type to auto so connection searches for all devices
-    args.trace = False # set trace_enabled to false, this is the default for esptool.
+    args.chip = 'auto'  # set chip type to auto so connection searches for all devices
+    args.trace = False  # set trace_enabled to false, this is the default for esptool.
     esp = esptool.connect_to_esp(args, args.baud)
 
     # dict mapping register name to its efuse object

--- a/espefuse.py
+++ b/espefuse.py
@@ -903,7 +903,7 @@ def main():
     parser.add_argument(
         '--port', '-p',
         help='Serial port device',
-        default=os.environ.get('ESPTOOL_PORT', esptool.ESPLoader.DEFAULT_PORT))
+        default=os.environ.get('ESPTOOL_PORT', None))
 
     parser.add_argument(
         '--before',
@@ -997,8 +997,10 @@ def main():
     # each 'operation' is a module-level function of the same name
     operation_func = globals()[args.operation]
 
-    esp = esptool.ESP32ROM(args.port, baud=args.baud)
-    esp.connect(args.before)
+    # Connect to a device at given port, or iterate through ports if none provided
+    args.chip = 'auto' # set chip type to auto so connection searches for all devices
+    args.trace = False # set trace_enabled to false, this is the default for esptool.
+    esp = esptool.connect_to_esp(args, args.baud)
 
     # dict mapping register name to its efuse object
     efuses = EspEfuses(esp)

--- a/esptool.py
+++ b/esptool.py
@@ -3174,6 +3174,7 @@ def expand_file_arguments():
         print("esptool.py %s" % (" ".join(new_args[1:])))
         sys.argv = new_args
 
+
 def connect_to_esp(args, initial_baud):
     """Connects to an esp device at provided serial port.
 
@@ -3206,8 +3207,9 @@ def connect_to_esp(args, initial_baud):
             print("%s failed to connect: %s" % (each_port, err))
             esp = None
     if esp is None:
-            raise FatalError("Could not connect to an Espressif device on any of the %d available serial ports." % len(ser_list))
+        raise FatalError("Could not connect to an Espressif device on any of the %d available serial ports." % len(ser_list))
     return esp
+
 
 class FlashSizeAction(argparse.Action):
     """ Custom flash size parser class to support backwards compatibility with megabit size arguments.


### PR DESCRIPTION
# Description of change
A very useful feature of `esptool.py` is its ability to find an ESP Device even when no `--port` option is provided *AND* the connected Device is not on the default port.

This ability to scan ports until it finds a device was introduced in #307 and is [specifically noted as a feature in the esptool docs as a new behavior as of v2.4.0](https://github.com/espressif/esptool#common-options)

This feature is currently missing from `espefuse.py`. In order to keep the logic of connecting to ESP Devices consistent, I've created this PR which re-organizes the serial port scanning logic in `esptool.py` so that it is re-usable, and gone ahead and utilized it within `espefuse.py`

With this change, `espefuse.py` and `esptool.py` now behave the same when no port is provided as an argument.

# I have tested this change with the following hardware & software combinations:

- Operating Systems
  - macOS (10.15.3 - Catalina)
  - Windows 10
- Python 3.8.1
- Hardware
  - ESP32-D0WDQ6

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

```shell
./test_imagegen.py
Running image generation tests...
............
----------------------------------------------------------------------
Ran 12 tests in 1.828s

OK

./test_esptool.py /dev/cu.SLAB_USBtoUART esp32 230400 
Running esptool.py tests...
..s....sss..............................s.......
----------------------------------------------------------------------
Ran 48 tests in 680.389s

OK (skipped=5)
```
