### PR TITLE
Use segments for app image generation (ESPTOOL-126)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2361,7 +2361,6 @@ class ELFFile(object):
         self._read_sections(f, shoff, shnum, shstrndx)
         self._read_segments(f, _phoff, _phnum, shstrndx)
 
-
     def _read_sections(self, f, section_header_offs, section_header_count, shstrndx):
         f.seek(section_header_offs)
         len_bytes = section_header_count * self.LEN_SEC_HEADER
@@ -2398,7 +2397,6 @@ class ELFFile(object):
         def lookup_string(offs):
             raw = string_table[offs:]
             return raw[:raw.index(b'\x00')]
-
 
         prog_sections = [ELFSection(lookup_string(n_offs), lma, read_data(offs, size)) for (n_offs, _type, lma, size, offs) in prog_sections
                          if lma != 0 and size > 0]
@@ -2918,7 +2916,7 @@ def elf2image(args):
         image = ESP8266V2FirmwareImage()
     image.entrypoint = e.entrypoint
     if args.use_segments:
-        image.segments = e.segments # ELFSection is a subclass of ImageSegment
+        image.segments = e.segments  # ELFSection is a subclass of ImageSegment
     else:
         image.segments = e.sections  # ELFSection is a subclass of ImageSegment
     image.flash_mode = {'qio':0, 'qout':1, 'dio':2, 'dout': 3}[args.flash_mode]

--- a/esptool.py
+++ b/esptool.py
@@ -2885,7 +2885,10 @@ def elf2image(args):
     else:
         image = ESP8266V2FirmwareImage()
     image.entrypoint = e.entrypoint
-    image.segments = e.sections  # ELFSection is a subclass of ImageSegment
+    if args.use_segments:
+        image.segments = e.segments # ELFSection is a subclass of ImageSegment
+    else:
+        image.segments = e.sections  # ELFSection is a subclass of ImageSegment
     image.flash_mode = {'qio':0, 'qout':1, 'dio':2, 'dout': 3}[args.flash_mode]
     image.flash_size_freq = image.ROM_LOADER.FLASH_SIZES[args.flash_size]
     image.flash_size_freq += {'40m':0, '26m':1, '20m':2, '80m': 0xf}[args.flash_freq]
@@ -3202,6 +3205,8 @@ def main(custom_commandline=None):
                                   'For Secure Boot v2 images only.')
     parser_elf2image.add_argument('--elf-sha256-offset', help='If set, insert SHA256 hash (32 bytes) of the input ELF file at specified offset in the binary.',
                                   type=arg_auto_int, default=None)
+    parser_elf2image.add_argument('--use_segments', help='If set, ELF segments will be used to instead of ELF sections to genereate the image.',
+                                  action='store_true')
 
     add_spi_flash_subparsers(parser_elf2image, is_elf2image=True)
 


### PR DESCRIPTION
# Description of change
This PR add a ```--use_segments``` to elf2image. This option use segments instead of sections in order to build the app image. This is usefull if there is more than 16 PROGBITS ELF sections (limit of app image segments).

[Here is a discusion about this](https://www.esp32.com/viewtopic.php?p=62918&sid=564af52d09a51a307f9e9ef9eba6eff6#p62918)

# I have tested this change with the following hardware & software combinations:

(Arch Linux (Linux 5.7.9), ESP32-DevKitC, ESP32-D0WDQ6)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:
```
....s......x...............................s.......
----------------------------------------------------------------------
Ran 51 tests in 788.711s

OK (skipped=2, expected failures=1)
```