### PR TITLE
Adding merge_image functionality (ESPTOOL-79)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -3147,6 +3147,8 @@ def make_image(args):
 
 
 def merge_image(args):
+    import espsecure
+
     # Helper classes
     class Bin(object):
         def __init__(self, addr, file):
@@ -3167,7 +3169,7 @@ def merge_image(args):
             self.output_folder = output_folder
             try:
                 os.makedirs(os.path.realpath(self.output_folder))
-            except:
+            except (FileExistsError, OSError):
                 pass
             self.output_path = os.path.realpath(os.path.join(self.output_folder, self.name))
             self.bin_array = []
@@ -3188,20 +3190,20 @@ def merge_image(args):
             with open(self.output_path, "a") as output_file:
                 output_file.write('\xff' * (binary.addr - previous))
             print("Add %s from 0x%x to 0x%x (0x%x)" % (
-            binary.file_name, binary.addr, binary.addr + binary.size, binary.size))
+                binary.file_name, binary.addr, binary.addr + binary.size, binary.size))
             with open(self.output_path, "a") as output_file:
                 output_file.write(binary.file.read())
             return binary.addr + binary.size
 
         def create_bin(self):
             new_start = 0
-            open(self.output_path, "wb").close
+            open(self.output_path, "wb").close()
             for b in self.bin_array:
                 new_start = self.add_bin_to_other_bin(new_start, b)
 
         def check_if_possible(self):
             for i in range(1, len(self.bin_array)):
-                if (self.bin_array[i].addr <= (self.bin_array[i - 1].addr + self.bin_array[i - 1].size)):
+                if self.bin_array[i].addr <= (self.bin_array[i - 1].addr + self.bin_array[i - 1].size):
                     print(self.bin_array[i].addr, (self.bin_array[i - 1].addr + self.bin_array[i - 1].size))
                     raise Exception("Not possible to create this bin, overlapping between %s and %s" % (
                         self.bin_array[i].file_name, self.bin_array[i - 1].file_name))
@@ -3580,7 +3582,7 @@ def main(custom_commandline=None):
     parser_merge_image.add_argument('--output', '-o', help='Output image file postfix (default: flash)', type=str, default='flash')
     parser_merge_image.add_argument('--keyfile', '-k', help="File with flash encryption key", type=argparse.FileType('rb'), default=None)
     parser_merge_image.add_argument('--flash_crypt_conf', help="Override FLASH_CRYPT_CONF efuse value (default: 0xF).",
-                                   default=0xF, type=arg_auto_int)
+                                    default=0xF, type=arg_auto_int)
 
     # Adding so we can use the same download.config for image composition
     add_spi_flash_subparsers(parser_merge_image, is_elf2image=False)

--- a/esptool.py
+++ b/esptool.py
@@ -3204,7 +3204,6 @@ def merge_image(args):
         def check_if_possible(self):
             for i in range(1, len(self.bin_array)):
                 if self.bin_array[i].addr <= (self.bin_array[i - 1].addr + self.bin_array[i - 1].size):
-                    print(self.bin_array[i].addr, (self.bin_array[i - 1].addr + self.bin_array[i - 1].size))
                     raise Exception("Not possible to create this bin, overlapping between %s and %s" % (
                         self.bin_array[i].file_name, self.bin_array[i - 1].file_name))
 

--- a/esptool.py
+++ b/esptool.py
@@ -3169,8 +3169,8 @@ def merge_image(args):
             self.output_folder = output_folder
             try:
                 os.makedirs(os.path.realpath(self.output_folder))
-            except (FileExistsError, OSError):
-                pass
+            except OSError:
+                pass    # file already exists, overwrite
             self.output_path = os.path.realpath(os.path.join(self.output_folder, self.name))
             self.bin_array = []
 

--- a/esptool.py
+++ b/esptool.py
@@ -3178,13 +3178,7 @@ def merge_image(args):
             self.bin_array.append(Bin(addr, file))
 
         def sort_bin(self):
-            swapped = True
-            while swapped:
-                swapped = False
-                for i in range(len(self.bin_array) - 1):
-                    if self.bin_array[i].addr > self.bin_array[i + 1].addr:
-                        self.bin_array[i], self.bin_array[i + 1] = self.bin_array[i + 1], self.bin_array[i]
-                        swapped = True
+            self.bin_array = sorted(self.bin_array, key=lambda b: b.addr)
 
         def add_bin_to_other_bin(self, previous, binary):
             with open(self.output_path, "a") as output_file:

--- a/esptool.py
+++ b/esptool.py
@@ -3172,13 +3172,13 @@ def merge_image(args):
             except OSError:
                 pass    # file already exists, overwrite
             self.output_path = os.path.realpath(os.path.join(self.output_folder, self.name))
-            self.bin_array = []
+            self.bins = []
 
         def add_bin(self, addr, file):
-            self.bin_array.append(Bin(addr, file))
+            self.bins.append(Bin(addr, file))
 
         def sort_bin(self):
-            self.bin_array = sorted(self.bin_array, key=lambda b: b.addr)
+            self.bins = sorted(self.bins, key=lambda b: b.addr)
 
         def add_bin_to_other_bin(self, previous, binary):
             with open(self.output_path, "a") as output_file:
@@ -3192,14 +3192,14 @@ def merge_image(args):
         def create_bin(self):
             new_start = 0
             open(self.output_path, "wb").close()
-            for b in self.bin_array:
+            for b in self.bins:
                 new_start = self.add_bin_to_other_bin(new_start, b)
 
         def check_if_possible(self):
-            for i in range(1, len(self.bin_array)):
-                if self.bin_array[i].addr <= (self.bin_array[i - 1].addr + self.bin_array[i - 1].size):
+            for i in range(1, len(self.bins)):
+                if self.bins[i].addr <= (self.bins[i - 1].addr + self.bins[i - 1].size):
                     raise Exception("Not possible to create this bin, overlapping between %s and %s" % (
-                        self.bin_array[i].file_name, self.bin_array[i - 1].file_name))
+                        self.bins[i].file_name, self.bins[i - 1].file_name))
 
     # Check that bins are provided
     if len(args.addr_filename) == 0:


### PR DESCRIPTION
# Description of change
Added command to merge multiple .bin files into one file for flashing.

Furthermore, you can create both unencrypted and encrypted images (-k is optional)
`esptool.py --port PORT merge_image -k flash_key.bin @download.config`

and flash those with 0x0 offset, for instance
`esptool.py --port PORT -b 460800 write_flash --flash_mode dio --flash_freq 40m --flash_size detect 0x0 flash.bin`

or similar (for the encrypted flash)
`esptool.py --port PORT -b 460800 write_flash --flash_mode dio --flash_freq 40m --flash_size detect 0x0 flash.enc.bin`

# This change fixes the following bug(s):
#254 

# I have tested this change with the following hardware & software combinations:
Ubuntu 18.04
ESP32-WROOM-32D
ESP32

# I have NOT run the esptool.py automated integration tests with this change and the above hardware.
This addition would not affect automated integration tests since this pull request does not modify existing functionality it appends it.

