### PR TITLE
setup.py: require wheel only when installing from pip (ESPTOOL-253)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,11 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
     ],
-    setup_requires=['wheel'] if sys.version_info[0:2] not in [(3, 4), (3, 5)] else [],
+    setup_requires=(
+        ['wheel']
+        if 'bdist_wheel' in sys.argv and sys.version_info[0:2] not in [(3, 4), (3, 5)] else
+        []
+    ),
     extras_require={
         "dev": [
             'flake8>=3.2.0',


### PR DESCRIPTION
Fix the build from sources (that don't require wheel) in environments where this module is not available.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>