### PR TITLE
start with python3 as default (ESPTOOL-257)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # ESP8266 & ESP32 ROM Bootloader Utility
 # Copyright (C) 2014-2016 Fredrik Ahlberg, Angus Gratton, Espressif Systems (Shanghai) PTE LTD, other contributors as noted.


### PR DESCRIPTION
# Description of change
1st line let's start with python3 by default

# This change fixes the following bug(s):

"Pyserial is not installed for /usr/bin/python" 

# I have tested this change with the following hardware & software combinations:

ESP8285 & Ubuntu20