### PR TITLE
Allow Popen.communicate() to read data from the pipe buffer instead of wait() (ESPTOOL-263)

### DIFF
--- a/test/test_espefuse_host.py
+++ b/test/test_espefuse_host.py
@@ -123,8 +123,8 @@ class EfuseTestCase(unittest.TestCase):
     def _run_command(self, cmd, check_msg, ret_code):
         try:
             p = subprocess.Popen(cmd.split(), shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
-            returncode = p.wait()
             output, _ = p.communicate()
+            returncode = p.returncode
             if check_msg:
                 self.assertIn(check_msg, output)
             if returncode:


### PR DESCRIPTION
```
Allow Popen.communicate() to read data from the pipe buffer instead of wait()

- The child process is blocked waiting for the OS pipe buffer to accept more data,
  while test_espefuse_host.py is waiting for the child process to terminate.

  On FreeBSD when a process tries to write(2) more than PIPE_MINDIRECT (8192 bytes) [0]
  at once, it will be blocked at pipe_direct_write() until the receiving process grabs
  all of the bytes from the pipe buffer.

  The test case "burn_efuse -h" [1] writes more than 8192 bytes to the pipe, then child
  process is in the block state (pipdwt) on FreeBSD and process test_espefuse_host.py
  is waiting for it to terminate.

- Popen.communicate() does the reading and calls wait() [2]

[0]: https://cgit.freebsd.org/src/tree/sys/kern/sys_pipe.c?h=releng/13.0#n1132
[1]: https://github.com/espressif/esptool/blob/v3.1/test/test_espefuse_host.py#L320
[2]: https://github.com/python/cpython/blob/v3.8.10/Lib/subprocess.py#L984-L1049
```