### PR TITLE
Fix chip detection of ESP32-C3 (ESPTOOL-266)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -2056,7 +2056,7 @@ class ESP32C3ROM(ESP32ROM):
         num_word = 3
         block1_addr = self.EFUSE_BASE + 0x044
         word3 = self.read_reg(block1_addr + (4 * num_word))
-        pkg_version = (word3 >> 21) & 0x0F
+        pkg_version = (word3 >> 21) & 0x07
         return pkg_version
 
     def get_chip_revision(self):


### PR DESCRIPTION
# Description of change

The ESP32-C3 is always detected as "unknown ESP32-C3" since the bit length of the efuse field it reads was wrong. This patch fixes the problem.

According to [esp_efuse_table.csv](https://github.com/espressif/esp-idf/blob/release/v4.3/components/efuse/esp32c3/esp_efuse_table.csv#L129), the length of `PKG_VERSION` should be 3 bits.

# This change fixes the following bug(s):

https://github.com/espressif/esptool/issues/638

# I have tested this change with the following hardware & software combinations:

* Hardware: ESP32-C3-DevKitM-1
* Software: macOS Big Sur 11.4, Python 3.9.5 (exported by ESP-IDF v4.3)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

(Details here: https://github.com/espressif/esptool/blob/master/CONTRIBUTING.md#automated-integration-tests )

```
$ ./test_imagegen.py
Running image generation tests...
.............
----------------------------------------------------------------------
Ran 13 tests in 2.603s

OK
```

```
$ ./test_esptool.py /dev/cu.usbserial-21340 esp32c3 230400
Running tests...
----------------------------------------------------------------------
Running esptool.py tests...
**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --port /dev/cu.usbserial-21340 --baud 230400 chip_id...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nDetecting chip type... ESP32-C3\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nWarning: ESP32-C3 has no Chip ID. Reading MAC instead.\nMAC: 7c:df:a1:c2:22:10\nHard resetting via RTS pin...\n'
.**************************************************
Server started successfully.
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --port rfc2217://localhost:51111?ign_set_control --baud 230400 chip_id...
b'esptool.py v3.2-dev\nSerial port rfc2217://localhost:51111?ign_set_control\nConnecting...\nDevice PID identification is only supported on COM and /dev/ serial ports.\n.\nDetecting chip type... ESP32-C3\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nWarning: ESP32-C3 has no Chip ID. Reading MAC instead.\nMAC: 7c:df:a1:c2:22:10\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fm dout -ff 20m 0x0 images/one_kb.bin...
b"esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nWarning: Image file at 0x0 doesn't look like an image file, so not changing any flash settings.\nCompressed 1024 bytes to 1035...\nWriting at 0x00000000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00000000 in 0.1 seconds (effective 89.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n"
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpnoy73ko9...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x0 in 0.1 seconds (151.1 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fm dout -ff 20m 0x0 images/one_kb_all_ef.bin...
b"esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nWarning: Image file at 0x0 doesn't look like an image file, so not changing any flash settings.\nCompressed 1024 bytes to 17...\nWriting at 0x00000000... (100 %)\nWrote 1024 bytes (17 compressed) at 0x00000000 in 0.0 seconds (effective 177.0 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n"
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp8y8sl25y...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x0 in 0.1 seconds (151.7 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fm dout -ff 20m 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00004fff...\nFlash params set to 0x0312\nCompressed 17744 bytes to 10472...\nWriting at 0x00000000... (100 %)\nWrote 17744 bytes (10472 compressed) at 0x00000000 in 0.8 seconds (effective 183.5 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
.s**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x10000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00010000 to 0x00010fff...\nCompressed 1024 bytes to 1035...\nWriting at 0x00010000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00010000 in 0.1 seconds (effective 92.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 65536 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpli07osq9...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x10000 in 0.1 seconds (150.6 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 erase_flash...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nErasing flash (this may take a while)...\nChip erase completed successfully in 15.9s\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 65536 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpv5zk7ihn...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x10000 in 0.1 seconds (149.5 kbit/s)...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 erase_region 0x0 0x100000...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nErasing region (may be slow depending on size)...\nErase completed successfully in 4.5 seconds.\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x10000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00010000 to 0x00010fff...\nCompressed 1024 bytes to 1035...\nWriting at 0x00010000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00010000 in 0.1 seconds (effective 90.0 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x11000 images/sector.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00011000 to 0x00011fff...\nCompressed 4096 bytes to 4107...\nWriting at 0x00011000... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00011000 in 0.2 seconds (effective 132.8 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 65536 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpnd0dwery...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x10000 in 0.1 seconds (150.5 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 69632 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmprt15nh_1...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x11000 in 0.2 seconds (166.5 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 erase_region 0x10000 0x1000...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nErasing region (may be slow depending on size)...\nErase completed successfully in 0.0 seconds.\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 69632 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpjrp448w1...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x11000 in 0.2 seconds (166.6 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 65536 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp0f9rxwug...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x10000 in 0.2 seconds (168.0 kbit/s)...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 flash_id...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nManufacturer: 20\nDevice: 4016\nDetected flash size: 4MB\nHard resetting via RTS pin...\n'
.sss**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs keep 0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00004fff...\nCompressed 17744 bytes to 10471...\nWriting at 0x00000000... (100 %)\nWrote 17744 bytes (10471 compressed) at 0x00000000 in 0.8 seconds (effective 185.5 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 17744 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp627104xh...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (23 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (46 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (69 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (92 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0817744 (100 %)\n17744 (100 %)\nRead 17744 bytes at 0x0 in 0.8 seconds (170.2 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 17744 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs 4MB 0x300000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00300000 to 0x00300fff...\nCompressed 1024 bytes to 1035...\nWriting at 0x00300000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00300000 in 0.1 seconds (effective 90.4 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 3145728 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp8cf1iv5g...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x300000 in 0.1 seconds (151.3 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u -fs 4MB 0x300000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00300000 to 0x00300fff...\nWriting at 0x00300000... (100 %)\nWrote 16384 bytes at 0x00300000 in 0.8 seconds (170.8 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 3145728 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpvilgqxdh...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x300000 in 0.1 seconds (150.5 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs 10MB 0x6000 images/one_kb.bin...
b'usage: esptool write_flash [-h] [--erase-all]\n                           [--flash_freq {keep,40m,26m,20m,80m}]\n                           [--flash_mode {keep,qio,qout,dio,dout}]\n                           [--flash_size FLASH_SIZE]\n                           [--spi-connection SPI_CONNECTION] [--no-progress]\n                           [--verify] [--encrypt]\n                           [--encrypt-files <address> <filename> [<address> <filename> ...]]\n                           [--ignore-flash-encryption-efuse-setting]\n                           [--compress | --no-compress]\n                           <address> <filename> [<address> <filename> ...]\nesptool write_flash: error: argument --flash_size/-fs: 10MB is not a known flash size. Known sizes: 512KB, 256KB, 1MB, 2MB, 4MB, 2MB-c1, 4MB-c1, 8MB, 16MB, detect, keep\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs 4MB 0x280000 images/one_mb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00280000 to 0x0037ffff...\nCompressed 1048576 bytes to 1048902...\nWriting at 0x00280000... (1 %)\nWriting at 0x00283ff9... (3 %)\nWriting at 0x00287ff4... (4 %)\nWriting at 0x0028bfef... (6 %)\nWriting at 0x0028ffea... (7 %)\nWriting at 0x00293fe5... (9 %)\nWriting at 0x00297fe0... (10 %)\nWriting at 0x0029bfdb... (12 %)\nWriting at 0x0029ffd6... (13 %)\nWriting at 0x002a3fd1... (15 %)\nWriting at 0x002a7fcc... (16 %)\nWriting at 0x002abfc7... (18 %)\nWriting at 0x002affc2... (20 %)\nWriting at 0x002b3fbd... (21 %)\nWriting at 0x002b7fb8... (23 %)\nWriting at 0x002bbfb3... (24 %)\nWriting at 0x002bffae... (26 %)\nWriting at 0x002c3fa9... (27 %)\nWriting at 0x002c7fa4... (29 %)\nWriting at 0x002cbf9f... (30 %)\nWriting at 0x002cff9a... (32 %)\nWriting at 0x002d3f95... (33 %)\nWriting at 0x002d7f90... (35 %)\nWriting at 0x002dbf8b... (36 %)\nWriting at 0x002dff86... (38 %)\nWriting at 0x002e3f81... (40 %)\nWriting at 0x002e7f7c... (41 %)\nWriting at 0x002ebf77... (43 %)\nWriting at 0x002eff72... (44 %)\nWriting at 0x002f3f6d... (46 %)\nWriting at 0x002f7f68... (47 %)\nWriting at 0x002fbf63... (49 %)\nWriting at 0x002fff5e... (50 %)\nWriting at 0x00303f59... (52 %)\nWriting at 0x00307f54... (53 %)\nWriting at 0x0030bf4f... (55 %)\nWriting at 0x0030ff4a... (56 %)\nWriting at 0x00313f45... (58 %)\nWriting at 0x00317f40... (60 %)\nWriting at 0x0031bf3b... (61 %)\nWriting at 0x0031ff36... (63 %)\nWriting at 0x00323f31... (64 %)\nWriting at 0x00327f2c... (66 %)\nWriting at 0x0032bf27... (67 %)\nWriting at 0x0032ff22... (69 %)\nWriting at 0x00333f1d... (70 %)\nWriting at 0x00337f18... (72 %)\nWriting at 0x0033bf13... (73 %)\nWriting at 0x0033ff0e... (75 %)\nWriting at 0x00343f09... (76 %)\nWriting at 0x00347f04... (78 %)\nWriting at 0x0034beff... (80 %)\nWriting at 0x0034fefa... (81 %)\nWriting at 0x00353ef5... (83 %)\nWriting at 0x00357ef0... (84 %)\nWriting at 0x0035beeb... (86 %)\nWriting at 0x0035fee6... (87 %)\nWriting at 0x00363ee1... (89 %)\nWriting at 0x00367edc... (90 %)\nWriting at 0x0036bed7... (92 %)\nWriting at 0x0036fed2... (93 %)\nWriting at 0x00373ecd... (95 %)\nWriting at 0x00377ec8... (96 %)\nWriting at 0x0037bec3... (98 %)\nWriting at 0x0037febe... (100 %)\nWrote 1048576 bytes (1048902 compressed) at 0x00280000 in 47.1 seconds (effective 178.1 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 2621440 1048576 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpweic7yrk...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (0 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (0 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (1 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (1 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (1 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (2 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (2 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (3 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (3 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (3 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (4 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (4 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0853248 (5 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0857344 (5 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0861440 (5 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0865536 (6 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0869632 (6 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0873728 (7 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0877824 (7 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0881920 (7 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0886016 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0890112 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0894208 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0898304 (9 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08102400 (9 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08106496 (10 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08110592 (10 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08114688 (10 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08118784 (11 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08122880 (11 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08126976 (12 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08131072 (12 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08135168 (12 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08139264 (13 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08143360 (13 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08147456 (14 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08151552 (14 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08155648 (14 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08159744 (15 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08163840 (15 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08167936 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08172032 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08176128 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08180224 (17 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08184320 (17 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08188416 (17 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08192512 (18 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08196608 (18 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08200704 (19 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08204800 (19 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08208896 (19 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08212992 (20 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08217088 (20 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08221184 (21 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08225280 (21 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08229376 (21 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08233472 (22 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08237568 (22 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08241664 (23 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08245760 (23 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08249856 (23 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08253952 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08258048 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08262144 (25 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08266240 (25 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08270336 (25 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08274432 (26 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08278528 (26 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08282624 (26 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08286720 (27 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08290816 (27 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08294912 (28 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08299008 (28 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08303104 (28 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08307200 (29 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08311296 (29 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08315392 (30 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08319488 (30 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08323584 (30 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08327680 (31 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08331776 (31 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08335872 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08339968 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08344064 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08348160 (33 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08352256 (33 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08356352 (33 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08360448 (34 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08364544 (34 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08368640 (35 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08372736 (35 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08376832 (35 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08380928 (36 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08385024 (36 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08389120 (37 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08393216 (37 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08397312 (37 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08401408 (38 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08405504 (38 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08409600 (39 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08413696 (39 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08417792 (39 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08421888 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08425984 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08430080 (41 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08434176 (41 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08438272 (41 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08442368 (42 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08446464 (42 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08450560 (42 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08454656 (43 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08458752 (43 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08462848 (44 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08466944 (44 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08471040 (44 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08475136 (45 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08479232 (45 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08483328 (46 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08487424 (46 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08491520 (46 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08495616 (47 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08499712 (47 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08503808 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08507904 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08512000 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08516096 (49 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08520192 (49 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08524288 (50 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08528384 (50 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08532480 (50 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08536576 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08540672 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08544768 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08548864 (52 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08552960 (52 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08557056 (53 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08561152 (53 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08565248 (53 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08569344 (54 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08573440 (54 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08577536 (55 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08581632 (55 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08585728 (55 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08589824 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08593920 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08598016 (57 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08602112 (57 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08606208 (57 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08610304 (58 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08614400 (58 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08618496 (58 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08622592 (59 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08626688 (59 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08630784 (60 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08634880 (60 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08638976 (60 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08643072 (61 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08647168 (61 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08651264 (62 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08655360 (62 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08659456 (62 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08663552 (63 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08667648 (63 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08671744 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08675840 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08679936 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08684032 (65 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08688128 (65 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08692224 (66 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08696320 (66 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08700416 (66 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08704512 (67 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08708608 (67 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08712704 (67 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08716800 (68 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08720896 (68 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08724992 (69 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08729088 (69 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08733184 (69 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08737280 (70 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08741376 (70 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08745472 (71 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08749568 (71 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08753664 (71 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08757760 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08761856 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08765952 (73 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08770048 (73 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08774144 (73 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08778240 (74 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08782336 (74 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08786432 (75 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08790528 (75 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08794624 (75 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08798720 (76 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08802816 (76 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08806912 (76 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08811008 (77 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08815104 (77 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08819200 (78 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08823296 (78 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08827392 (78 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08831488 (79 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08835584 (79 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08839680 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08843776 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08847872 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08851968 (81 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08856064 (81 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08860160 (82 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08864256 (82 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08868352 (82 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08872448 (83 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08876544 (83 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08880640 (83 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08884736 (84 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08888832 (84 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08892928 (85 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08897024 (85 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08901120 (85 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08905216 (86 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08909312 (86 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08913408 (87 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08917504 (87 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08921600 (87 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08925696 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08929792 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08933888 (89 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08937984 (89 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08942080 (89 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08946176 (90 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08950272 (90 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08954368 (91 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08958464 (91 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08962560 (91 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08966656 (92 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08970752 (92 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08974848 (92 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08978944 (93 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08983040 (93 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08987136 (94 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08991232 (94 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08995328 (94 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08999424 (95 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081003520 (95 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081007616 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081011712 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081015808 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081019904 (97 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081024000 (97 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081028096 (98 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081032192 (98 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081036288 (98 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081040384 (99 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081044480 (99 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081048576 (100 %)\n1048576 (100 %)\nRead 1048576 bytes at 0x280000 in 49.1 seconds (170.8 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1048576 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u -fs 4MB 0x280000 images/one_mb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00280000 to 0x0037ffff...\nWriting at 0x00280000... (1 %)\nWriting at 0x00284000... (3 %)\nWriting at 0x00288000... (4 %)\nWriting at 0x0028c000... (6 %)\nWriting at 0x00290000... (7 %)\nWriting at 0x00294000... (9 %)\nWriting at 0x00298000... (10 %)\nWriting at 0x0029c000... (12 %)\nWriting at 0x002a0000... (14 %)\nWriting at 0x002a4000... (15 %)\nWriting at 0x002a8000... (17 %)\nWriting at 0x002ac000... (18 %)\nWriting at 0x002b0000... (20 %)\nWriting at 0x002b4000... (21 %)\nWriting at 0x002b8000... (23 %)\nWriting at 0x002bc000... (25 %)\nWriting at 0x002c0000... (26 %)\nWriting at 0x002c4000... (28 %)\nWriting at 0x002c8000... (29 %)\nWriting at 0x002cc000... (31 %)\nWriting at 0x002d0000... (32 %)\nWriting at 0x002d4000... (34 %)\nWriting at 0x002d8000... (35 %)\nWriting at 0x002dc000... (37 %)\nWriting at 0x002e0000... (39 %)\nWriting at 0x002e4000... (40 %)\nWriting at 0x002e8000... (42 %)\nWriting at 0x002ec000... (43 %)\nWriting at 0x002f0000... (45 %)\nWriting at 0x002f4000... (46 %)\nWriting at 0x002f8000... (48 %)\nWriting at 0x002fc000... (50 %)\nWriting at 0x00300000... (51 %)\nWriting at 0x00304000... (53 %)\nWriting at 0x00308000... (54 %)\nWriting at 0x0030c000... (56 %)\nWriting at 0x00310000... (57 %)\nWriting at 0x00314000... (59 %)\nWriting at 0x00318000... (60 %)\nWriting at 0x0031c000... (62 %)\nWriting at 0x00320000... (64 %)\nWriting at 0x00324000... (65 %)\nWriting at 0x00328000... (67 %)\nWriting at 0x0032c000... (68 %)\nWriting at 0x00330000... (70 %)\nWriting at 0x00334000... (71 %)\nWriting at 0x00338000... (73 %)\nWriting at 0x0033c000... (75 %)\nWriting at 0x00340000... (76 %)\nWriting at 0x00344000... (78 %)\nWriting at 0x00348000... (79 %)\nWriting at 0x0034c000... (81 %)\nWriting at 0x00350000... (82 %)\nWriting at 0x00354000... (84 %)\nWriting at 0x00358000... (85 %)\nWriting at 0x0035c000... (87 %)\nWriting at 0x00360000... (89 %)\nWriting at 0x00364000... (90 %)\nWriting at 0x00368000... (92 %)\nWriting at 0x0036c000... (93 %)\nWriting at 0x00370000... (95 %)\nWriting at 0x00374000... (96 %)\nWriting at 0x00378000... (98 %)\nWriting at 0x0037c000... (100 %)\nWrote 1048576 bytes at 0x00280000 in 46.9 seconds (178.9 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 2621440 1048576 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp7row0l15...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (0 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (0 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (1 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (1 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (1 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (2 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (2 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (3 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (3 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (3 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (4 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (4 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0853248 (5 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0857344 (5 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0861440 (5 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0865536 (6 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0869632 (6 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0873728 (7 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0877824 (7 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0881920 (7 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0886016 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0890112 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0894208 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0898304 (9 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08102400 (9 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08106496 (10 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08110592 (10 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08114688 (10 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08118784 (11 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08122880 (11 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08126976 (12 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08131072 (12 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08135168 (12 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08139264 (13 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08143360 (13 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08147456 (14 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08151552 (14 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08155648 (14 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08159744 (15 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08163840 (15 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08167936 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08172032 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08176128 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08180224 (17 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08184320 (17 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08188416 (17 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08192512 (18 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08196608 (18 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08200704 (19 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08204800 (19 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08208896 (19 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08212992 (20 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08217088 (20 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08221184 (21 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08225280 (21 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08229376 (21 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08233472 (22 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08237568 (22 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08241664 (23 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08245760 (23 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08249856 (23 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08253952 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08258048 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08262144 (25 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08266240 (25 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08270336 (25 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08274432 (26 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08278528 (26 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08282624 (26 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08286720 (27 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08290816 (27 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08294912 (28 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08299008 (28 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08303104 (28 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08307200 (29 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08311296 (29 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08315392 (30 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08319488 (30 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08323584 (30 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08327680 (31 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08331776 (31 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08335872 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08339968 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08344064 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08348160 (33 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08352256 (33 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08356352 (33 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08360448 (34 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08364544 (34 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08368640 (35 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08372736 (35 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08376832 (35 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08380928 (36 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08385024 (36 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08389120 (37 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08393216 (37 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08397312 (37 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08401408 (38 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08405504 (38 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08409600 (39 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08413696 (39 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08417792 (39 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08421888 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08425984 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08430080 (41 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08434176 (41 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08438272 (41 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08442368 (42 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08446464 (42 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08450560 (42 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08454656 (43 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08458752 (43 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08462848 (44 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08466944 (44 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08471040 (44 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08475136 (45 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08479232 (45 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08483328 (46 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08487424 (46 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08491520 (46 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08495616 (47 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08499712 (47 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08503808 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08507904 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08512000 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08516096 (49 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08520192 (49 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08524288 (50 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08528384 (50 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08532480 (50 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08536576 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08540672 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08544768 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08548864 (52 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08552960 (52 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08557056 (53 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08561152 (53 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08565248 (53 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08569344 (54 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08573440 (54 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08577536 (55 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08581632 (55 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08585728 (55 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08589824 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08593920 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08598016 (57 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08602112 (57 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08606208 (57 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08610304 (58 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08614400 (58 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08618496 (58 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08622592 (59 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08626688 (59 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08630784 (60 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08634880 (60 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08638976 (60 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08643072 (61 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08647168 (61 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08651264 (62 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08655360 (62 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08659456 (62 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08663552 (63 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08667648 (63 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08671744 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08675840 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08679936 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08684032 (65 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08688128 (65 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08692224 (66 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08696320 (66 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08700416 (66 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08704512 (67 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08708608 (67 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08712704 (67 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08716800 (68 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08720896 (68 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08724992 (69 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08729088 (69 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08733184 (69 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08737280 (70 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08741376 (70 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08745472 (71 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08749568 (71 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08753664 (71 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08757760 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08761856 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08765952 (73 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08770048 (73 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08774144 (73 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08778240 (74 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08782336 (74 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08786432 (75 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08790528 (75 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08794624 (75 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08798720 (76 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08802816 (76 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08806912 (76 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08811008 (77 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08815104 (77 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08819200 (78 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08823296 (78 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08827392 (78 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08831488 (79 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08835584 (79 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08839680 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08843776 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08847872 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08851968 (81 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08856064 (81 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08860160 (82 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08864256 (82 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08868352 (82 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08872448 (83 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08876544 (83 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08880640 (83 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08884736 (84 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08888832 (84 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08892928 (85 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08897024 (85 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08901120 (85 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08905216 (86 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08909312 (86 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08913408 (87 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08917504 (87 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08921600 (87 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08925696 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08929792 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08933888 (89 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08937984 (89 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08942080 (89 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08946176 (90 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08950272 (90 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08954368 (91 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08958464 (91 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08962560 (91 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08966656 (92 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08970752 (92 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08974848 (92 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08978944 (93 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08983040 (93 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08987136 (94 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08991232 (94 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08995328 (94 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08999424 (95 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081003520 (95 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081007616 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081011712 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081015808 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081019904 (97 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081024000 (97 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081028096 (98 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081032192 (98 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081036288 (98 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081040384 (99 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081044480 (99 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x081048576 (100 %)\n1048576 (100 %)\nRead 1048576 bytes at 0x280000 in 49.1 seconds (170.8 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1048576 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u -fs 1MB 0x280000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\n\nA fatal error occurred: File images/one_kb.bin (length 1024) at offset 2621440 will not fit in 1048576 bytes of flash. Use --flash-size argument, or change flashing address.\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs 1MB 0x280000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\n\nA fatal error occurred: File images/one_kb.bin (length 1024) at offset 2621440 will not fit in 1048576 bytes of flash. Use --flash-size argument, or change flashing address.\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/sector.bin 0x1000 images/fifty_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nFlash will be erased from 0x00001000 to 0x0000dfff...\nCompressed 4096 bytes to 4107...\nWriting at 0x00000000... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00000000 in 0.2 seconds (effective 131.4 kbit/s)...\nHash of data verified.\nCompressed 51200 bytes to 51226...\nWriting at 0x00001000... (25 %)\nWriting at 0x00004ff9... (50 %)\nWriting at 0x00008ff4... (75 %)\nWriting at 0x0000cfef... (100 %)\nWrote 51200 bytes (51226 compressed) at 0x00001000 in 2.9 seconds (effective 143.2 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpi7ujt2n1...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x0 in 0.2 seconds (167.2 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 4096 51200 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp5etf7vpa...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0851200 (100 %)\n51200 (100 %)\nRead 51200 bytes at 0x1000 in 2.4 seconds (170.7 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 51200 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/sector.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nCompressed 4096 bytes to 4107...\nWriting at 0x00000000... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00000000 in 0.2 seconds (effective 132.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpud_tn08u...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x0 in 0.2 seconds (166.9 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x1000 images/fifty_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00001000 to 0x0000dfff...\nCompressed 51200 bytes to 51226...\nWriting at 0x00001000... (25 %)\nWriting at 0x00004ff9... (50 %)\nWriting at 0x00008ff4... (75 %)\nWriting at 0x0000cfef... (100 %)\nWrote 51200 bytes (51226 compressed) at 0x00001000 in 2.9 seconds (effective 142.4 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 4096 51200 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp99332n7u...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0851200 (100 %)\n51200 (100 %)\nRead 51200 bytes at 0x1000 in 2.4 seconds (170.7 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 51200 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpbuiq1a4i...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x0 in 0.2 seconds (166.6 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --no-stub write_flash -z 0x0 images/sector.bin 0x1000 images/fifty_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nChanging baud rate to 230400\nChanged.\nEnabling default SPI flash mode...\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nFlash will be erased from 0x00001000 to 0x0000dfff...\nErasing flash...\nCompressed 4096 bytes to 4107...\nTook 0.04s to erase flash block\nWriting at 0x00000000... (20 %)\nWriting at 0x000003f9... (40 %)\nWriting at 0x000007f9... (60 %)\nWriting at 0x00000bf9... (80 %)\nWriting at 0x00000ff9... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00000000 in 0.2 seconds (effective 139.2 kbit/s)...\nHash of data verified.\nErasing flash...\nCompressed 51200 bytes to 51226...\nTook 0.44s to erase flash block\nWriting at 0x00001000... (1 %)\nWriting at 0x000013f9... (3 %)\nWriting at 0x000017f9... (5 %)\nWriting at 0x00001bf9... (7 %)\nWriting at 0x00001ff9... (9 %)\nWriting at 0x000023f9... (11 %)\nWriting at 0x000027f9... (13 %)\nWriting at 0x00002bf9... (15 %)\nWriting at 0x00002ff9... (17 %)\nWriting at 0x000033f9... (19 %)\nWriting at 0x000037f9... (21 %)\nWriting at 0x00003bf9... (23 %)\nWriting at 0x00003ff9... (25 %)\nWriting at 0x000043f9... (27 %)\nWriting at 0x000047f9... (29 %)\nWriting at 0x00004bf9... (31 %)\nWriting at 0x00004ff9... (33 %)\nWriting at 0x000053f4... (35 %)\nWriting at 0x000057f4... (37 %)\nWriting at 0x00005bf4... (39 %)\nWriting at 0x00005ff4... (41 %)\nWriting at 0x000063f4... (43 %)\nWriting at 0x000067f4... (45 %)\nWriting at 0x00006bf4... (47 %)\nWriting at 0x00006ff4... (49 %)\nWriting at 0x000073f4... (50 %)\nWriting at 0x000077f4... (52 %)\nWriting at 0x00007bf4... (54 %)\nWriting at 0x00007ff4... (56 %)\nWriting at 0x000083f4... (58 %)\nWriting at 0x000087f4... (60 %)\nWriting at 0x00008bf4... (62 %)\nWriting at 0x00008ff4... (64 %)\nWriting at 0x000093ef... (66 %)\nWriting at 0x000097ef... (68 %)\nWriting at 0x00009bef... (70 %)\nWriting at 0x00009fef... (72 %)\nWriting at 0x0000a3ef... (74 %)\nWriting at 0x0000a7ef... (76 %)\nWriting at 0x0000abef... (78 %)\nWriting at 0x0000afef... (80 %)\nWriting at 0x0000b3ef... (82 %)\nWriting at 0x0000b7ef... (84 %)\nWriting at 0x0000bbef... (86 %)\nWriting at 0x0000bfef... (88 %)\nWriting at 0x0000c3ef... (90 %)\nWriting at 0x0000c7ef... (92 %)\nWriting at 0x0000cbef... (94 %)\nWriting at 0x0000cfef... (96 %)\nWriting at 0x0000d3ea... (98 %)\nWriting at 0x0000d7ea... (100 %)\nWrote 51200 bytes (51226 compressed) at 0x00001000 in 2.8 seconds (effective 144.3 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpmow6djse...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x0 in 0.2 seconds (167.2 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 4096 51200 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp3tdfzvsw...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0851200 (100 %)\n51200 (100 %)\nRead 51200 bytes at 0x1000 in 2.4 seconds (170.8 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 51200 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x10000 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpcbupgjku...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00010000 to 0x0010ffff...\nCompressed 1048576 bytes to 1039...\nWriting at 0x00010000... (100 %)\nWrote 1048576 bytes (1039 compressed) at 0x00010000 in 10.8 seconds (effective 778.8 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x10000 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmppi2fy51g...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00010000 to 0x00104fff...\nCompressed 1000000 bytes to 1289...\nWriting at 0x00010000... (100 %)\nWrote 1000000 bytes (1289 compressed) at 0x00010000 in 10.4 seconds (effective 770.4 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x2000 images/sector.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00002000 to 0x00002fff...\nCompressed 4096 bytes to 4107...\nWriting at 0x00002000... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00002000 in 0.2 seconds (effective 132.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 12288 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpf49fr25g...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (33 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (66 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (100 %)\n12288 (100 %)\nRead 12288 bytes at 0x0 in 0.6 seconds (169.9 kbit/s)...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x1000 images/bootloader_esp32.bin 0x0FC00 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00001000 to 0x00002fff...\nWARNING: Flash address 0x0000fc00 is not aligned to a 0x1000 byte flash sector. 0xc00 bytes before this address will be erased.\nFlash will be erased from 0x0000f000 to 0x0000ffff...\nCompressed 7888 bytes to 4535...\nWriting at 0x00001000... (100 %)\nWrote 7888 bytes (4535 compressed) at 0x00001000 in 0.3 seconds (effective 185.9 kbit/s)...\nHash of data verified.\nCompressed 1024 bytes to 1035...\nWriting at 0x0000fc00... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x0000fc00 in 0.1 seconds (effective 91.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 921600 write_flash 0x0 images/fifty_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 921600\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x0000cfff...\nCompressed 51200 bytes to 51226...\nWriting at 0x00000000... (25 %)\nWriting at 0x00003ff9... (50 %)\nWriting at 0x00007ff4... (75 %)\nWriting at 0x0000bfef... (100 %)\nWrote 51200 bytes (51226 compressed) at 0x00000000 in 1.3 seconds (effective 322.9 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 51200 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpysovw23y...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0851200 (100 %)\n51200 (100 %)\nRead 51200 bytes at 0x0 in 2.4 seconds (170.8 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 51200 bytes
.**************************************************
Server started successfully.
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port rfc2217://localhost:52109?ign_set_control --baud 921600 write_flash 0x0 images/fifty_kb.bin...
b'esptool.py v3.2-dev\nSerial port rfc2217://localhost:52109?ign_set_control\nConnecting...\nDevice PID identification is only supported on COM and /dev/ serial ports.\n.\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 921600\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x0000cfff...\nCompressed 51200 bytes to 51226...\nWriting at 0x00000000... (25 %)\nWriting at 0x00003ff9... (50 %)\nWriting at 0x00007ff4... (75 %)\nWriting at 0x0000bfef... (100 %)\nWrote 51200 bytes (51226 compressed) at 0x00000000 in 2.3 seconds (effective 177.9 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 51200 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmptbs7y2gl...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0851200 (100 %)\n51200 (100 %)\nRead 51200 bytes at 0x0 in 2.4 seconds (170.7 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 51200 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/nodemcu-master-7-modules-2017-01-19-11-10-03-integer.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x0005ffff...\nCompressed 390412 bytes to 250019...\nWriting at 0x00000000... (6 %)\nWriting at 0x00005368... (12 %)\nWriting at 0x0001470b... (18 %)\nWriting at 0x00019e6b... (25 %)\nWriting at 0x0001f781... (31 %)\nWriting at 0x00024ecc... (37 %)\nWriting at 0x0002a753... (43 %)\nWriting at 0x0002f853... (50 %)\nWriting at 0x00034892... (56 %)\nWriting at 0x00039bb9... (62 %)\nWriting at 0x0003ffb1... (68 %)\nWriting at 0x000459cb... (75 %)\nWriting at 0x0004b15e... (81 %)\nWriting at 0x00050a71... (87 %)\nWriting at 0x00056921... (93 %)\nWriting at 0x0005d1b2... (100 %)\nWrote 390412 bytes (250019 compressed) at 0x00000000 in 11.9 seconds (effective 262.1 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u 0x0 images/nodemcu-master-7-modules-2017-01-19-11-10-03-integer.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x0005ffff...\nWriting at 0x00000000... (4 %)\nWriting at 0x00004000... (8 %)\nWriting at 0x00008000... (12 %)\nWriting at 0x0000c000... (16 %)\nWriting at 0x00010000... (20 %)\nWriting at 0x00014000... (25 %)\nWriting at 0x00018000... (29 %)\nWriting at 0x0001c000... (33 %)\nWriting at 0x00020000... (37 %)\nWriting at 0x00024000... (41 %)\nWriting at 0x00028000... (45 %)\nWriting at 0x0002c000... (50 %)\nWriting at 0x00030000... (54 %)\nWriting at 0x00034000... (58 %)\nWriting at 0x00038000... (62 %)\nWriting at 0x0003c000... (66 %)\nWriting at 0x00040000... (70 %)\nWriting at 0x00044000... (75 %)\nWriting at 0x00048000... (79 %)\nWriting at 0x0004c000... (83 %)\nWriting at 0x00050000... (87 %)\nWriting at 0x00054000... (91 %)\nWriting at 0x00058000... (95 %)\nWriting at 0x0005c000... (100 %)\nWrote 393216 bytes at 0x00000000 in 17.8 seconds (176.6 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u 0x0 images/sector.bin 0x1000 images/fifty_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nFlash will be erased from 0x00001000 to 0x0000dfff...\nWriting at 0x00000000... (100 %)\nWrote 16384 bytes at 0x00000000 in 0.8 seconds (167.3 kbit/s)...\nHash of data verified.\nWriting at 0x00001000... (25 %)\nWriting at 0x00005000... (50 %)\nWriting at 0x00009000... (75 %)\nWriting at 0x0000d000... (100 %)\nWrote 65536 bytes at 0x00001000 in 2.9 seconds (178.8 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpztq7m9l9...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x0 in 0.2 seconds (167.3 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 4096 51200 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp9rh522z4...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (8 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x088192 (16 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0812288 (24 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0816384 (32 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0820480 (40 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0824576 (48 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0828672 (56 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0832768 (64 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0836864 (72 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0840960 (80 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0845056 (88 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0849152 (96 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x0851200 (100 %)\n51200 (100 %)\nRead 51200 bytes at 0x1000 in 2.4 seconds (170.6 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 51200 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x4000 images/partitions_singleapp.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00004000 to 0x00004fff...\nCompressed 96 bytes to 57...\nWriting at 0x00004000... (100 %)\nWrote 96 bytes (57 compressed) at 0x00004000 in 0.0 seconds (effective 17.0 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 16384 96 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpaqemx7r9...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n96 (100 %)\n96 (100 %)\nRead 96 bytes at 0x4000 in 0.0 seconds (61.4 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 96 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x1000 images/bootloader_esp32.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00001000 to 0x00002fff...\nCompressed 7888 bytes to 4535...\nWriting at 0x00001000... (100 %)\nWrote 7888 bytes (4535 compressed) at 0x00001000 in 0.3 seconds (effective 186.2 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 4096 7888 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp3tnig4dj...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x087888 (100 %)\n7888 (100 %)\nRead 7888 bytes at 0x1000 in 0.4 seconds (168.8 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 7888 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 16384 96 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp9txi1xz7...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n96 (100 %)\n96 (100 %)\nRead 96 bytes at 0x4000 in 0.0 seconds (58.5 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 96 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u 0x4000 images/partitions_singleapp.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00004000 to 0x00004fff...\nWriting at 0x00004000... (100 %)\nWrote 16384 bytes at 0x00004000 in 0.8 seconds (172.3 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 16384 96 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpdyfbudgr...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n96 (100 %)\n96 (100 %)\nRead 96 bytes at 0x4000 in 0.0 seconds (62.6 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 96 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u 0x1000 images/bootloader_esp32.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00001000 to 0x00002fff...\nWriting at 0x00001000... (100 %)\nWrote 16384 bytes at 0x00001000 in 0.8 seconds (155.2 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 4096 7888 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp1pco5g60...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x087888 (100 %)\n7888 (100 %)\nRead 7888 bytes at 0x1000 in 0.4 seconds (169.2 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 7888 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 16384 96 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpdhrcqu_d...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n96 (100 %)\n96 (100 %)\nRead 96 bytes at 0x4000 in 0.0 seconds (61.9 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 96 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --no-stub write_flash 0x4000 images/partitions_singleapp.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nChanging baud rate to 230400\nChanged.\nEnabling default SPI flash mode...\nConfiguring flash size...\nFlash will be erased from 0x00004000 to 0x00004fff...\nErasing flash...\nTook 0.04s to erase flash block\nWriting at 0x00004000... (100 %)\nWrote 1024 bytes at 0x00004000 in 0.1 seconds (144.2 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 16384 96 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpumkby852...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n96 (100 %)\n96 (100 %)\nRead 96 bytes at 0x4000 in 0.0 seconds (62.7 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 96 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --no-stub write_flash 0x1000 images/bootloader_esp32.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nChanging baud rate to 230400\nChanged.\nEnabling default SPI flash mode...\nConfiguring flash size...\nFlash will be erased from 0x00001000 to 0x00002fff...\nErasing flash...\nTook 0.08s to erase flash block\nWriting at 0x00001000... (12 %)\nWriting at 0x00001400... (25 %)\nWriting at 0x00001800... (37 %)\nWriting at 0x00001c00... (50 %)\nWriting at 0x00002000... (62 %)\nWriting at 0x00002400... (75 %)\nWriting at 0x00002800... (87 %)\nWriting at 0x00002c00... (100 %)\nWrote 8192 bytes at 0x00001000 in 0.5 seconds (139.2 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 4096 7888 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmplltduov_...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (51 %)\x08\x08\x08\x08\x08\x08\x08\x08\x08\x08\x087888 (100 %)\n7888 (100 %)\nRead 7888 bytes at 0x1000 in 0.4 seconds (168.8 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 7888 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 16384 96 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp3axfcxom...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n96 (100 %)\n96 (100 %)\nRead 96 bytes at 0x4000 in 0.0 seconds (62.4 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 96 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/one_kb.bin 0x0 images/one_kb.bin...
b'usage: esptool write_flash [-h] [--erase-all]\n                           [--flash_freq {keep,40m,26m,20m,80m}]\n                           [--flash_mode {keep,qio,qout,dio,dout}]\n                           [--flash_size FLASH_SIZE]\n                           [--spi-connection SPI_CONNECTION] [--no-progress]\n                           [--verify] [--encrypt]\n                           [--encrypt-files <address> <filename> [<address> <filename> ...]]\n                           [--ignore-flash-encryption-efuse-setting]\n                           [--compress | --no-compress]\n                           <address> <filename> [<address> <filename> ...]\nesptool write_flash: error: argument <address> <filename>: Detected overlap at address: 0x0 for file: images/one_kb.bin\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nCompressed 1024 bytes to 1035...\nWriting at 0x00000000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00000000 in 0.1 seconds (effective 87.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpzk4lygjs...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x0 in 0.1 seconds (147.7 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/onebyte.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00000fff...\nCompressed 4 bytes to 12...\nWriting at 0x00000000... (100 %)\nWrote 4 bytes (12 compressed) at 0x00000000 in 0.0 seconds (effective 0.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 1 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp05ytu2ey...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1 (100 %)\n1 (100 %)\nRead 1 bytes at 0x0 in 0.0 seconds (1.0 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/bootloader_esp32.bin 0x2000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00001fff...\nFlash will be erased from 0x00002000 to 0x00002fff...\nCompressed 7888 bytes to 4535...\nWriting at 0x00000000... (100 %)\nWrote 7888 bytes (4535 compressed) at 0x00000000 in 0.3 seconds (effective 187.5 kbit/s)...\nHash of data verified.\nCompressed 1024 bytes to 1035...\nWriting at 0x00002000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00002000 in 0.1 seconds (effective 90.1 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/bootloader_esp32.bin 0x1000 images/one_kb.bin...
b'usage: esptool write_flash [-h] [--erase-all]\n                           [--flash_freq {keep,40m,26m,20m,80m}]\n                           [--flash_mode {keep,qio,qout,dio,dout}]\n                           [--flash_size FLASH_SIZE]\n                           [--spi-connection SPI_CONNECTION] [--no-progress]\n                           [--verify] [--encrypt]\n                           [--encrypt-files <address> <filename> [<address> <filename> ...]]\n                           [--ignore-flash-encryption-efuse-setting]\n                           [--compress | --no-compress]\n                           <address> <filename> [<address> <filename> ...]\nesptool write_flash: error: argument <address> <filename>: Detected overlap at address: 0x1000 for file: images/one_kb.bin\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0xd00 images/one_kb.bin 0x1d00 images/one_kb.bin...
b'usage: esptool write_flash [-h] [--erase-all]\n                           [--flash_freq {keep,40m,26m,20m,80m}]\n                           [--flash_mode {keep,qio,qout,dio,dout}]\n                           [--flash_size FLASH_SIZE]\n                           [--spi-connection SPI_CONNECTION] [--no-progress]\n                           [--verify] [--encrypt]\n                           [--encrypt-files <address> <filename> [<address> <filename> ...]]\n                           [--ignore-flash-encryption-efuse-setting]\n                           [--compress | --no-compress]\n                           <address> <filename> [<address> <filename> ...]\nesptool write_flash: error: argument <address> <filename>: Detected overlap at address: 0x1d00 for file: images/one_kb.bin\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x10000 images/one_kb.bin 0x11000 images/zerolength.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00010000 to 0x00010fff...\nFlash will be erased from 0x00011000 to 0x00010fff...\nCompressed 1024 bytes to 1035...\nWriting at 0x00010000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00010000 in 0.1 seconds (effective 89.7 kbit/s)...\nHash of data verified.\nWARNING: File images/zerolength.bin is empty\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 65536 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp_8rd8iij...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0x10000 in 0.1 seconds (151.1 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs detect 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nAuto-detected Flash size: 4MB\nFlash will be erased from 0x00000000 to 0x00004fff...\nFlash params set to 0x0220\nCompressed 17744 bytes to 10471...\nWriting at 0x00000000... (100 %)\nWrote 17744 bytes (10471 compressed) at 0x00000000 in 0.8 seconds (effective 182.9 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 8 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp6amg1fs2...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n8 (100 %)\n8 (100 %)\nRead 8 bytes at 0x0 in 0.0 seconds (7.7 kbit/s)...\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs 2MB -fm dout -ff 80m 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00004fff...\nFlash params set to 0x031f\nCompressed 17744 bytes to 10472...\nWriting at 0x00000000... (100 %)\nWrote 17744 bytes (10472 compressed) at 0x00000000 in 0.8 seconds (effective 183.0 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 8 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp7kqlgfte...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n8 (100 %)\n8 (100 %)\nRead 8 bytes at 0x0 in 0.0 seconds (7.1 kbit/s)...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 verify_flash -fs 2MB -fm dout -ff 80m 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash params set to 0x031f\nVerifying 0x4550 (17744) bytes @ 0x00000000 in flash against images/bootloader_esp32c3.bin...\n-- verify OK (digest matched)\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 verify_flash 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nVerifying 0x4550 (17744) bytes @ 0x00000000 in flash against images/bootloader_esp32c3.bin...\n-- verify FAILED (digest mismatch)\n\nA fatal error occurred: Verify failed.\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fs keep 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00004fff...\nCompressed 17744 bytes to 10471...\nWriting at 0x00000000... (100 %)\nWrote 17744 bytes (10471 compressed) at 0x00000000 in 0.8 seconds (effective 182.4 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 8 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp0l6n23yu...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n8 (100 %)\n8 (100 %)\nRead 8 bytes at 0x0 in 0.0 seconds (7.5 kbit/s)...\nHard resetting via RTS pin...\n'
WARNING: Expected length 17744 doesn't match comparison 8
Readback 8 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -fm keep -ff keep -fs keep 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x00004fff...\nCompressed 17744 bytes to 10471...\nWriting at 0x00000000... (100 %)\nWrote 17744 bytes (10471 compressed) at 0x00000000 in 0.8 seconds (effective 184.6 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 0 8 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp7komtoaa...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n8 (100 %)\n8 (100 %)\nRead 8 bytes at 0x0 in 0.0 seconds (6.9 kbit/s)...\nHard resetting via RTS pin...\n'
WARNING: Expected length 17744 doesn't match comparison 8
Readback 8 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 verify_flash -fs keep 0x0 images/bootloader_esp32c3.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nVerifying 0x4550 (17744) bytes @ 0x00000000 in flash against images/bootloader_esp32c3.bin...\n-- verify OK (digest matched)\nHard resetting via RTS pin...\n'
.s**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 dump_mem 0x50000000 128 memout.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nRead 128 bytes\nDone!\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 read_mem 0x400C0000...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n0x400c0000 = 0x00000000\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_mem 0x400C0000 0xabad1dea 0x0000ffff...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nWrote abad1dea, mask 0000ffff to 400c0000\nHard resetting via RTS pin...\n'
.s**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 read_mac...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nMAC: 7c:df:a1:c2:22:10\nHard resetting via RTS pin...\n'
.**************************************************
Serial port /dev/cu.usbserial-21340
Connecting....
using test address 0x50000000
.**************************************************
Serial port /dev/cu.usbserial-21340
Connecting....
Uploading stub...
Running stub...
Stub running...
using test address 0x50000000
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x10000 images/sector.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00010000 to 0x00010fff...\nCompressed 4096 bytes to 4107...\nWriting at 0x00010000... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00010000 in 0.2 seconds (effective 132.4 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0FC00 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nWARNING: Flash address 0x0000fc00 is not aligned to a 0x1000 byte flash sector. 0xc00 bytes before this address will be erased.\nFlash will be erased from 0x0000f000 to 0x0000ffff...\nCompressed 1024 bytes to 1035...\nWriting at 0x0000fc00... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x0000fc00 in 0.1 seconds (effective 91.9 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 64512 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpatbovdk5...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0xfc00 in 0.1 seconds (150.1 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 65536 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp0i9mq8zq...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x10000 in 0.2 seconds (167.5 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u 0x10000 images/sector.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00010000 to 0x00010fff...\nWriting at 0x00010000... (100 %)\nWrote 16384 bytes at 0x00010000 in 0.8 seconds (167.7 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash -u 0x0FC00 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nWARNING: Flash address 0x0000fc00 is not aligned to a 0x1000 byte flash sector. 0xc00 bytes before this address will be erased.\nFlash will be erased from 0x0000f000 to 0x0000ffff...\nWriting at 0x0000fc00... (100 %)\nWrote 16384 bytes at 0x0000fc00 in 0.8 seconds (171.3 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 64512 1024 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmp0c4ak8cl...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n1024 (100 %)\n1024 (100 %)\nRead 1024 bytes at 0xfc00 in 0.1 seconds (150.4 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 1024 bytes
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 65536 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpizyngc6h...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x10000 in 0.2 seconds (167.2 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x20800 images/sector.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nWARNING: Flash address 0x00020800 is not aligned to a 0x1000 byte flash sector. 0x800 bytes before this address will be erased.\nFlash will be erased from 0x00020000 to 0x00021fff...\nCompressed 4096 bytes to 4107...\nWriting at 0x00020800... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00020800 in 0.3 seconds (effective 116.1 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before default_reset read_flash 133120 4096 /var/folders/r_/1tjm6w9j75ddqgy2x30m3jrr0000gn/T/tmpt3yti0g6...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\n4096 (100 %)\n4096 (100 %)\nRead 4096 bytes at 0x20800 in 0.2 seconds (167.2 kbit/s)...\nHard resetting via RTS pin...\n'
Readback 4096 bytes
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --after no_reset_stub flash_id...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nManufacturer: 20\nDevice: 4016\nDetected flash size: 4MB\nStaying in flasher stub.\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 --before no_reset flash_id...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nWARNING: Pre-connection option "no_reset" was selected. Connection may fail if the chip is not in bootloader or flasher stub mode.\nConnecting........_____....._____....._____....._____....._____....._____....._____\n\nA fatal error occurred: Failed to connect to ESP32-C3: Timed out waiting for packet header\n'
Es**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x6000 images/sector.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00006000 to 0x00006fff...\nCompressed 4096 bytes to 4107...\nWriting at 0x00006000... (100 %)\nWrote 4096 bytes (4107 compressed) at 0x00006000 in 0.2 seconds (effective 134.0 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 verify_flash --diff=yes 0x6000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nVerifying 0x400 (1024) bytes @ 0x00006000 in flash against images/one_kb.bin...\n-- verify FAILED: 1022 differences, first @ 0x00006000\n   00006000 16 ed\n   00006001 c7 8a\n   00006002 2b 75\n   00006003 b3 c0\n   00006004 05 56\n   00006005 12 15\n   00006006 8c 57\n   00006007 12 a5\n   00006008 89 06\n   00006009 5d 21\n   0000600a 50 b0\n   0000600b 4f 4e\n   0000600c aa 73\n   0000600d b5 05\n   0000600e 14 6c\n   0000600f c5 df\n   00006010 1d 3b\n   00006011 ab 30\n   00006012 eb 2e\n   00006013 8b 11\n   00006014 a3 7c\n   00006015 8b d5\n   00006016 fa ad\n   00006017 55 77\n   00006018 ab fa\n   00006019 a5 e2\n   0000601a 98 ad\n   0000601b 2f 47\n   0000601c c8 ce\n   0000601d fd 22\n   0000601e ae 82\n   0000601f e6 b5\n   00006020 8a 67\n   00006021 84 a7\n   00006022 22 3d\n   00006023 85 7a\n   00006024 c2 f3\n   00006025 79 49\n   00006026 3c 9b\n   00006027 1b b3\n   00006028 b5 3c\n   00006029 8e 12\n   0000602a 67 3d\n   0000602b b6 fa\n   0000602c d8 f1\n   0000602d 09 86\n   0000602e 76 1a\n   0000602f 96 75\n   00006030 ec 7d\n   00006031 ea 01\n   00006032 fc 25\n   00006033 8a fa\n   00006034 3f da\n   00006035 49 5c\n   00006036 0b d1\n   00006037 72 90\n   00006038 10 a5\n   00006039 58 23\n   0000603a ff 31\n   0000603b 04 9e\n   0000603c b9 46\n   0000603d a7 06\n   0000603e 77 ec\n   0000603f fc a0\n   00006040 5e e6\n   00006041 71 3e\n   00006042 e4 c4\n   00006043 38 7a\n   00006044 90 3a\n   00006045 80 c6\n   00006046 8f 64\n   00006047 cb 5e\n   00006048 9a a7\n   00006049 87 74\n   0000604a 19 5c\n   0000604b d7 36\n   0000604c d7 c4\n   0000604d 55 2d\n   0000604e b5 61\n   0000604f c8 7e\n   00006050 10 3d\n   00006051 52 64\n   00006052 b9 1e\n   00006053 47 c1\n   00006054 6c a9\n   00006055 7e 75\n   00006056 6d 33\n   00006057 6e 1f\n   00006058 7c 10\n   00006059 d1 ca\n   0000605a 18 65\n   0000605b 41 85\n   0000605c b5 22\n   0000605d be 11\n   0000605e fc 8b\n   0000605f c3 49\n   00006060 e8 ae\n   00006061 ec 32\n   00006062 a2 ca\n   00006063 69 82\n   00006064 11 26\n   00006065 87 6e\n   00006066 dd 87\n   00006067 c5 35\n   00006068 4f de\n   00006069 62 b5\n   0000606a 55 8a\n   0000606b 8d 82\n   0000606c 30 16\n   0000606d 95 5e\n   0000606e 8b c7\n   0000606f 47 58\n   00006070 a3 a9\n   00006071 3d 17\n   00006072 38 71\n   00006073 c8 69\n   00006074 df 94\n   00006076 7a c3\n   00006077 70 e9\n   00006078 63 22\n   00006079 72 df\n   0000607a c9 ab\n   0000607b bc eb\n   0000607c 73 a5\n   0000607d a5 ee\n   0000607e a4 dd\n   0000607f 47 57\n   00006080 01 16\n   00006081 96 a4\n   00006082 56 04\n   00006083 90 3a\n   00006084 78 74\n   00006085 21 9f\n   00006086 16 67\n   00006087 9d a9\n   00006088 17 d6\n   00006089 d5 7c\n   0000608a 7b b9\n   0000608b cb 9f\n   0000608c 97 83\n   0000608d 23 1c\n   0000608e 70 b4\n   0000608f 8d 99\n   00006090 32 7d\n   00006091 c5 fc\n   00006092 3b 32\n   00006093 c6 86\n   00006094 3e b6\n   00006095 51 23\n   00006096 75 9c\n   00006097 ed cc\n   00006098 12 3a\n   00006099 20 4c\n   0000609a 9f 38\n   0000609b 07 e9\n   0000609c 7e b4\n   0000609d 9c 0c\n   0000609e 4d ec\n   0000609f 5d eb\n   000060a0 2f 43\n   000060a1 d6 2e\n   000060a2 ce 1a\n   000060a3 e4 f4\n   000060a4 d7 f5\n   000060a5 ff bd\n   000060a6 92 5e\n   000060a7 92 a9\n   000060a8 22 69\n   000060a9 93 b8\n   000060aa 9d fb\n   000060ab fc 29\n   000060ac 6f f8\n   000060ad 9b 03\n   000060ae 2a c9\n   000060af 5e 1c\n   000060b0 f1 23\n   000060b1 c1 14\n   000060b2 91 7b\n   000060b3 d4 49\n   000060b4 3d 90\n   000060b5 25 c4\n   000060b6 58 4f\n   000060b7 c2 04\n   000060b8 b8 1e\n   000060b9 36 69\n   000060ba de 84\n   000060bb 10 ab\n   000060bc c9 81\n   000060bd f6 d5\n   000060be 7e 1d\n   000060bf 84 e4\n   000060c0 db cd\n   000060c1 12 0a\n   000060c2 af 0f\n   000060c3 a5 d8\n   000060c4 6e 49\n   000060c5 ad 71\n   000060c6 73 b6\n   000060c7 3e ee\n   000060c8 d1 78\n   000060c9 30 ab\n   000060ca 85 08\n   000060cb a4 79\n   000060cc 70 1d\n   000060cd 43 06\n   000060ce e2 3a\n   000060cf 73 eb\n   000060d0 5a c1\n   000060d1 42 a0\n   000060d2 e4 ba\n   000060d3 64 6b\n   000060d4 5b 54\n   000060d5 23 8c\n   000060d6 7d b9\n   000060d7 8d 92\n   000060d8 ea 3f\n   000060d9 56 7b\n   000060da bd bb\n   000060db 27 4a\n   000060dc 3e 7e\n   000060dd 29 59\n   000060de 99 7f\n   000060df 7e d5\n   000060e0 96 7a\n   000060e1 c9 6f\n   000060e2 78 b8\n   000060e3 93 eb\n   000060e4 8b d4\n   000060e5 7b 96\n   000060e6 f2 89\n   000060e7 0e 31\n   000060e8 40 8c\n   000060e9 f3 0c\n   000060ea 08 1c\n   000060eb 55 29\n   000060ec 90 5b\n   000060ed 05 65\n   000060ee a4 0a\n   000060ef 8b 66\n   000060f0 9d 73\n   000060f1 c5 d4\n   000060f2 e6 bb\n   000060f3 cd 68\n   000060f4 b4 e7\n   000060f5 53 e5\n   000060f6 a0 89\n   000060f7 7b 2f\n   000060f8 f7 ff\n   000060f9 37 b5\n   000060fa df ef\n   000060fb ff d6\n   000060fc aa 89\n   000060fd c1 9a\n   000060fe ab 44\n   000060ff af ff\n   00006100 30 ca\n   00006101 f6 20\n   00006102 0e aa\n   00006103 33 7a\n   00006104 9c 0f\n   00006105 c0 c9\n   00006106 aa d0\n   00006107 c5 31\n   00006108 de 8d\n   00006109 09 9f\n   0000610a c5 32\n   0000610b 64 cc\n   0000610c 0c 9f\n   0000610d ad d7\n   0000610e 41 07\n   0000610f bc d9\n   00006110 81 d7\n   00006111 f5 56\n   00006112 29 ac\n   00006113 18 cc\n   00006114 81 b1\n   00006115 e4 33\n   00006116 16 21\n   00006117 57 a5\n   00006118 44 b9\n   00006119 f5 ff\n   0000611a e1 7a\n   0000611b d9 f3\n   0000611c 13 9b\n   0000611d 0e 07\n   0000611e ea c6\n   0000611f fa d0\n   00006120 da 38\n   00006121 db a9\n   00006122 2a 99\n   00006123 15 0b\n   00006124 7e 83\n   00006125 ae bb\n   00006126 2c 12\n   00006127 e3 80\n   00006128 b4 f4\n   00006129 d9 c5\n   0000612a a3 c6\n   0000612b 56 ba\n   0000612c 12 9a\n   0000612d 7f 92\n   0000612e 37 24\n   0000612f 48 c9\n   00006130 b0 90\n   00006131 9d e3\n   00006132 76 0c\n   00006133 fb a6\n   00006134 17 52\n   00006135 d5 b6\n   00006136 0b 80\n   00006137 4b b8\n   00006138 a7 ff\n   00006139 84 41\n   0000613a 0e 8d\n   0000613b 22 e6\n   0000613c 0e 04\n   0000613d c9 ad\n   0000613e 8f c2\n   0000613f 79 dc\n   00006140 07 ee\n   00006141 06 5e\n   00006142 27 7f\n   00006143 61 c2\n   00006144 09 9d\n   00006145 9b 2e\n   00006146 fc 1b\n   00006147 75 d6\n   00006148 aa b2\n   00006149 ba 7e\n   0000614a 24 a0\n   0000614b f6 d1\n   0000614c 29 35\n   0000614d 5e fc\n   0000614e c1 71\n   0000614f a2 ca\n   00006150 a9 d0\n   00006151 51 b5\n   00006152 d5 17\n   00006153 75 b1\n   00006154 93 b3\n   00006155 c0 3b\n   00006156 83 69\n   00006157 72 61\n   00006158 86 79\n   00006159 cf d4\n   0000615a 1d 3d\n   0000615b d3 8e\n   0000615c 13 e4\n   0000615d d4 04\n   0000615e e7 62\n   0000615f ef e3\n   00006160 22 0f\n   00006161 c5 d9\n   00006162 a3 00\n   00006163 57 c7\n   00006164 ca 6c\n   00006165 59 55\n   00006166 11 68\n   00006167 9d 86\n   00006168 c0 07\n   00006169 fb 2e\n   0000616a 28 e9\n   0000616b 66 01\n   0000616c 94 ae\n   0000616d 40 ba\n   0000616e a1 d6\n   0000616f 00 5e\n   00006170 ea 8a\n   00006171 a1 3c\n   00006172 2c c9\n   00006173 22 c7\n   00006174 31 ef\n   00006175 a9 0d\n   00006176 b3 b5\n   00006177 a4 3b\n   00006178 f2 36\n   00006179 bd 28\n   0000617a 74 b2\n   0000617b 3b 25\n   0000617c 43 19\n   0000617d 8e 58\n   0000617e 6d e1\n   0000617f 44 da\n   00006180 a1 b6\n   00006181 98 e2\n   00006182 ca 05\n   00006183 7e b2\n   00006184 10 72\n   00006185 0b e9\n   00006186 72 7e\n   00006187 5d cc\n   00006188 5b ff\n   00006189 4c 3a\n   0000618a 87 f3\n   0000618b f9 80\n   0000618c 51 43\n   0000618d 96 42\n   0000618e 44 23\n   0000618f fc 06\n   00006190 9f 34\n   00006191 6e bd\n   00006192 b5 00\n   00006193 d9 1e\n   00006194 c4 9a\n   00006195 07 8d\n   00006196 ae 34\n   00006197 c2 5d\n   00006198 17 5f\n   00006199 26 14\n   0000619a 04 43\n   0000619b 89 0d\n   0000619c 5a 7d\n   0000619d 23 84\n   0000619f 5d 1f\n   000061a0 0b 0c\n   000061a1 61 0c\n   000061a2 ba 85\n   000061a3 10 21\n   000061a4 6e 4f\n   000061a5 d0 d9\n   000061a6 8d 48\n   000061a7 30 cf\n   000061a8 c1 48\n   000061a9 f9 3d\n   000061aa 32 9c\n   000061ab ff a2\n   000061ac d1 ee\n   000061ad a9 3d\n   000061ae 35 78\n   000061af 14 67\n   000061b0 fd d9\n   000061b1 41 58\n   000061b2 23 49\n   000061b3 69 6d\n   000061b4 6c a6\n   000061b5 37 25\n   000061b6 31 7f\n   000061b7 b4 41\n   000061b8 1d 1a\n   000061b9 e7 05\n   000061ba 43 2d\n   000061bb 1e 8e\n   000061bc 48 d6\n   000061bd 9d 4c\n   000061be 4f 46\n   000061bf 54 00\n   000061c0 97 c2\n   000061c1 eb ed\n   000061c2 b9 98\n   000061c3 95 99\n   000061c4 a1 31\n   000061c5 eb df\n   000061c6 e0 56\n   000061c7 a3 08\n   000061c8 86 3a\n   000061c9 80 dd\n   000061ca ad 0b\n   000061cb 6a 21\n   000061cc 10 25\n   000061cd 20 ee\n   000061ce 1a 44\n   000061cf 46 10\n   000061d0 06 04\n   000061d1 9b 36\n   000061d2 dc 33\n   000061d3 67 cb\n   000061d4 b9 9f\n   000061d5 03 a6\n   000061d6 fe e7\n   000061d7 2c ef\n   000061d8 db 2e\n   000061d9 75 30\n   000061da fa 1a\n   000061db 3f f6\n   000061dc a5 37\n   000061dd b3 ad\n   000061de 13 be\n   000061df 32 c9\n   000061e0 b7 d4\n   000061e1 a9 87\n   000061e2 38 ac\n   000061e3 43 ca\n   000061e4 a9 24\n   000061e5 39 d7\n   000061e6 fd 67\n   000061e7 a0 0f\n   000061e8 51 c7\n   000061e9 6a 2c\n   000061ea 9f 7c\n   000061eb fc ff\n   000061ec 43 8f\n   000061ed ff 7f\n   000061ee e7 f3\n   000061ef be 77\n   000061f0 bf ed\n   000061f1 91 e7\n   000061f2 51 68\n   000061f3 9f 1c\n   000061f4 2a 72\n   000061f5 5d 58\n   000061f6 8c 94\n   000061f7 4f a1\n   000061f8 d6 c2\n   000061f9 f6 73\n   000061fa 10 da\n   000061fb 6b 94\n   000061fc d4 cd\n   000061fd 2b d8\n   000061fe 74 98\n   000061ff e6 5d\n   00006200 04 5b\n   00006201 5b b1\n   00006202 e3 a2\n   00006203 99 f8\n   00006204 0a 56\n   00006205 c6 1b\n   00006206 a1 89\n   00006207 a7 c8\n   00006208 14 19\n   00006209 da f3\n   0000620a 6a 2c\n   0000620b a2 73\n   0000620c 57 a6\n   0000620d 6e c4\n   0000620e d1 e2\n   0000620f 3a 5d\n   00006210 b8 0b\n   00006211 5b a1\n   00006212 9e 69\n   00006213 20 62\n   00006214 59 67\n   00006215 9a b9\n   00006216 df a8\n   00006217 29 98\n   00006218 c4 6e\n   00006219 06 1e\n   0000621a 28 77\n   0000621b 07 64\n   0000621c 1a 05\n   0000621d 0c b8\n   0000621e 23 2a\n   0000621f b4 23\n   00006220 34 47\n   00006221 52 2d\n   00006222 a7 bc\n   00006223 b9 07\n   00006224 9b 0c\n   00006225 f4 60\n   00006226 8c 50\n   00006227 8a 3e\n   00006228 f9 c8\n   00006229 4a d2\n   0000622a 6f c9\n   0000622b 6d 82\n   0000622c 65 b4\n   0000622d 42 30\n   0000622e fa 6b\n   0000622f a8 72\n   00006230 d5 8a\n   00006231 87 ec\n   00006232 58 de\n   00006233 0f e1\n   00006234 6a f0\n   00006235 99 5a\n   00006236 f8 a3\n   00006237 5b bf\n   00006238 62 67\n   00006239 b3 66\n   0000623a d7 dd\n   0000623b e4 48\n   0000623c 8c 5b\n   0000623d 30 d7\n   0000623e b4 f4\n   0000623f 5e a0\n   00006240 8e d1\n   00006241 4d 68\n   00006242 3a fd\n   00006243 a8 a9\n   00006244 90 bf\n   00006245 bf 1d\n   00006246 56 fc\n   00006247 90 5b\n   00006248 ab 8a\n   00006249 f1 92\n   0000624a 3f 78\n   0000624b 1f 9f\n   0000624c 81 31\n   0000624d c7 1c\n   0000624e 79 99\n   0000624f ed 58\n   00006250 c6 90\n   00006251 77 4d\n   00006252 bb 5f\n   00006253 75 b0\n   00006254 19 25\n   00006255 b9 cf\n   00006256 1f bb\n   00006257 52 c3\n   00006258 8e 6a\n   00006259 d8 c8\n   0000625a c4 42\n   0000625b 58 c5\n   0000625c 78 9e\n   0000625d c2 a2\n   0000625e 15 e8\n   0000625f dd cd\n   00006260 1a 90\n   00006261 b1 52\n   00006262 20 2c\n   00006263 6c 93\n   00006264 bf 39\n   00006265 ae 79\n   00006266 30 20\n   00006267 a3 ec\n   00006268 47 ad\n   00006269 38 16\n   0000626a a0 d5\n   0000626b 2a b0\n   0000626c a9 9d\n   0000626d 31 17\n   0000626e 88 4a\n   0000626f 7e 75\n   00006270 94 44\n   00006271 fb 43\n   00006272 33 f9\n   00006273 df 31\n   00006274 d2 8f\n   00006275 70 91\n   00006276 24 ef\n   00006277 60 57\n   00006278 1c d5\n   00006279 56 f8\n   0000627a 2f 06\n   0000627b 22 5f\n   0000627c ab d2\n   0000627d 24 65\n   0000627e 87 97\n   0000627f e5 cd\n   00006280 e3 e4\n   00006281 f8 a8\n   00006282 8a 8d\n   00006283 1f d8\n   00006284 4b 24\n   00006285 28 df\n   00006286 f8 f9\n   00006287 95 84\n   00006288 f1 16\n   00006289 9a 47\n   0000628a bf 85\n   0000628b 64 2e\n   0000628c 89 c8\n   0000628d 97 2f\n   0000628e 44 f4\n   0000628f 22 3d\n   00006290 3e dd\n   00006291 24 7c\n   00006292 5c 4f\n   00006293 ea ff\n   00006294 40 7f\n   00006295 7a 46\n   00006296 cf d1\n   00006297 2f c7\n   00006298 d3 5e\n   00006299 07 76\n   0000629a 9d 32\n   0000629b 89 f5\n   0000629c 32 59\n   0000629d 49 99\n   0000629e 62 c3\n   0000629f f9 76\n   000062a0 a4 6c\n   000062a1 91 e0\n   000062a2 32 38\n   000062a3 c4 2c\n   000062a4 e8 d1\n   000062a5 0d 60\n   000062a6 7c 3a\n   000062a7 c0 8d\n   000062a8 0c eb\n   000062a9 e6 93\n   000062aa 1e bf\n   000062ab ea be\n   000062ac 32 10\n   000062ad 1e ff\n   000062ae 51 f3\n   000062af c8 e0\n   000062b0 76 9d\n   000062b1 6b 52\n   000062b2 39 9f\n   000062b3 af 0b\n   000062b4 24 cc\n   000062b5 9c 68\n   000062b6 d7 09\n   000062b7 2d 27\n   000062b8 d4 61\n   000062b9 69 ba\n   000062ba 7c 83\n   000062bb 22 24\n   000062bc 5d 32\n   000062bd 7e 6b\n   000062be 3f 2c\n   000062bf b6 3a\n   000062c0 f3 18\n   000062c1 c2 ae\n   000062c2 60 b0\n   000062c3 07 3d\n   000062c4 65 c6\n   000062c5 fc af\n   000062c6 c4 05\n   000062c7 17 c5\n   000062c8 82 47\n   000062c9 87 a5\n   000062ca c6 d4\n   000062cb 61 1e\n   000062cc 46 1c\n   000062cd 80 96\n   000062ce f3 67\n   000062cf 32 59\n   000062d0 7f de\n   000062d1 f0 d0\n   000062d2 3d 3f\n   000062d3 bd db\n   000062d4 0e 03\n   000062d5 eb 83\n   000062d6 6b aa\n   000062d7 69 e5\n   000062d8 ef b1\n   000062d9 c2 b4\n   000062da 5f 8d\n   000062db 95 71\n   000062dc 9d 3a\n   000062dd 08 10\n   000062de 39 77\n   000062df cf 9d\n   000062e0 96 0a\n   000062e1 6a c6\n   000062e2 c6 16\n   000062e3 36 de\n   000062e4 f4 93\n   000062e5 b4 5a\n   000062e6 f9 13\n   000062e7 ee af\n   000062e8 9e 34\n   000062e9 21 35\n   000062ea d5 16\n   000062eb 50 90\n   000062ec 0c 81\n   000062ed 3c 06\n   000062ee 77 92\n   000062ef 52 c8\n   000062f0 81 93\n   000062f1 cb 05\n   000062f2 ee 8c\n   000062f3 f5 39\n   000062f4 a6 b4\n   000062f5 02 28\n   000062f6 f7 7e\n   000062f7 7e 0f\n   000062f8 f6 e4\n   000062f9 e0 30\n   000062fa 19 01\n   000062fb 67 33\n   000062fc d8 63\n   000062fd e4 ca\n   000062fe 93 c8\n   000062ff 15 46\n   00006300 1c aa\n   00006301 b3 68\n   00006302 0d 18\n   00006303 63 4e\n   00006304 4c 7c\n   00006305 15 1e\n   00006306 ec ea\n   00006307 3b c9\n   00006308 61 00\n   00006309 67 7d\n   0000630a 84 18\n   0000630b 8e 83\n   0000630c 85 09\n   0000630d 9d cb\n   0000630e 59 0e\n   0000630f dd 0a\n   00006310 86 7d\n   00006311 08 8a\n   00006312 83 d8\n   00006313 2c 37\n   00006314 67 6f\n   00006315 5e 22\n   00006316 e1 a5\n   00006317 c1 04\n   00006318 f1 4f\n   00006319 2a 30\n   0000631a 64 44\n   0000631b 32 e4\n   0000631c fd ed\n   0000631d 5a 9a\n   0000631e 9b 32\n   0000631f 4f c8\n   00006320 d5 de\n   00006321 03 f0\n   00006322 b3 be\n   00006323 c3 06\n   00006324 9e 6b\n   00006325 a8 08\n   00006326 b9 7d\n   00006327 5b 3c\n   00006328 05 8b\n   00006329 08 0d\n   0000632a 3b e1\n   0000632b b3 15\n   0000632c b3 1d\n   0000632d 49 ce\n   0000632e a5 c8\n   0000632f 6c 58\n   00006330 0e ba\n   00006331 17 f4\n   00006332 e2 0c\n   00006333 85 15\n   00006334 88 01\n   00006335 50 e2\n   00006336 10 02\n   00006337 f1 9e\n   00006338 1e d2\n   00006339 02 58\n   0000633a 1d a7\n   0000633b 79 b3\n   0000633c 4b 55\n   0000633d 3e be\n   0000633e d8 6f\n   0000633f 8f 69\n   00006340 77 91\n   00006341 7e 46\n   00006342 e5 16\n   00006343 6b 0b\n   00006344 95 87\n   00006345 ba 36\n   00006346 da 1a\n   00006347 02 10\n   00006348 b6 5c\n   00006349 03 0e\n   0000634a 48 f4\n   0000634b b6 4d\n   0000634c 2d 54\n   0000634d c9 b9\n   0000634e 8c 19\n   0000634f ac f4\n   00006350 87 ea\n   00006351 aa 43\n   00006352 6b b5\n   00006353 72 1d\n   00006354 b0 1a\n   00006355 c6 ee\n   00006356 5d be\n   00006357 d2 0c\n   00006358 5c ae\n   00006359 0a f1\n   0000635a 1d 89\n   0000635b 94 45\n   0000635c fe 30\n   0000635d a6 3c\n   0000635e fc c2\n   0000635f a3 d1\n   00006360 11 71\n   00006361 c9 3d\n   00006362 62 36\n   00006363 fa 3e\n   00006364 47 17\n   00006365 4f a0\n   00006366 f2 ed\n   00006367 40 19\n   00006368 ad f4\n   00006369 41 18\n   0000636a 21 65\n   0000636b 05 17\n   0000636c 58 c5\n   0000636d 65 50\n   0000636e f3 81\n   0000636f 8c 33\n   00006370 2e 25\n   00006371 9f 4a\n   00006372 5a 53\n   00006373 81 cf\n   00006374 d3 87\n   00006375 e7 99\n   00006376 b4 25\n   00006377 04 f7\n   00006378 f1 1e\n   00006379 e4 2f\n   0000637a 20 d2\n   0000637b 71 4c\n   0000637c a2 d2\n   0000637d 6a 3d\n   0000637e 3d 66\n   0000637f 23 6d\n   00006380 06 30\n   00006381 2d b4\n   00006382 58 32\n   00006383 a7 d4\n   00006384 36 76\n   00006385 86 62\n   00006386 d0 47\n   00006387 ed fb\n   00006388 d5 00\n   00006389 96 91\n   0000638a 98 b7\n   0000638b 45 38\n   0000638c ec 91\n   0000638d f1 fd\n   0000638e 62 89\n   0000638f 93 b8\n   00006390 dc 30\n   00006391 56 c7\n   00006392 b5 21\n   00006393 f5 b2\n   00006394 3f 16\n   00006395 dd 1a\n   00006396 2a e9\n   00006397 0e 5c\n   00006398 de 17\n   00006399 5a 80\n   0000639a fb 03\n   0000639b 3f e0\n   0000639c b3 cf\n   0000639d 0d 76\n   0000639e 7c a6\n   0000639f 9b 7f\n   000063a0 7e 23\n   000063a1 8d f7\n   000063a2 b0 27\n   000063a3 61 56\n   000063a4 86 43\n   000063a5 fe bb\n   000063a6 5d cb\n   000063a7 ec a0\n   000063a8 0e 46\n   000063a9 21 28\n   000063aa 08 4c\n   000063ab 0c d1\n   000063ac 7a 43\n   000063ad b9 06\n   000063ae fa 47\n   000063af de 30\n   000063b0 b5 09\n   000063b1 c7 95\n   000063b2 c5 75\n   000063b3 a5 ab\n   000063b4 80 95\n   000063b5 4a 6c\n   000063b6 76 94\n   000063b7 31 3c\n   000063b8 1b e6\n   000063b9 24 a0\n   000063ba 07 7d\n   000063bb a5 2f\n   000063bc c8 5d\n   000063bd 88 80\n   000063be 7a f3\n   000063bf 24 10\n   000063c0 6f 23\n   000063c1 2e 48\n   000063c2 5c f9\n   000063c3 c6 30\n   000063c4 af 04\n   000063c5 5b 9b\n   000063c6 88 b3\n   000063c7 a7 b7\n   000063c8 8d a0\n   000063c9 c3 af\n   000063ca a6 0f\n   000063cb 65 ba\n   000063cc 75 7a\n   000063cd b0 a1\n   000063ce b4 e4\n   000063cf fa c5\n   000063d0 1a 7e\n   000063d1 39 0e\n   000063d2 34 64\n   000063d3 e6 4a\n   000063d4 5a 91\n   000063d5 a0 15\n   000063d6 35 67\n   000063d7 a7 ef\n   000063d8 46 bf\n   000063d9 97 18\n   000063da cd 1d\n   000063db 9f 87\n   000063dc 83 af\n   000063dd e8 5a\n   000063de 9f 07\n   000063df 26 4b\n   000063e0 dc e5\n   000063e1 85 be\n   000063e2 d7 35\n   000063e3 68 72\n   000063e4 3e 65\n   000063e5 fe 5b\n   000063e6 48 88\n   000063e7 fe 88\n   000063e8 6f a2\n   000063e9 d6 e8\n   000063ea 4d 1a\n   000063eb b7 fd\n   000063ec fe 61\n   000063ed f8 de\n   000063ee 27 03\n   000063ef e4 a9\n   000063f0 68 7f\n   000063f1 ca 3d\n   000063f2 59 77\n   000063f3 b3 18\n   000063f4 9f 5d\n   000063f5 d0 5e\n   000063f6 e4 90\n   000063f7 a4 5a\n   000063f8 18 66\n   000063f9 48 10\n   000063fa d2 17\n   000063fb d4 89\n   000063fc ae 94\n   000063fd 07 91\n   000063fe 10 fe\n   000063ff 85 5d\n\nA fatal error occurred: Verify failed.\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x5000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00005000 to 0x00005fff...\nCompressed 1024 bytes to 1035...\nWriting at 0x00005000... (100 %)\nWrote 1024 bytes (1035 compressed) at 0x00005000 in 0.1 seconds (effective 87.6 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 verify_flash 0x5000 images/one_kb.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nVerifying 0x400 (1024) bytes @ 0x00005000 in flash against images/one_kb.bin...\n-- verify OK (digest matched)\nHard resetting via RTS pin...\n'
.**************************************************
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 write_flash 0x0 images/nodemcu-master-7-modules-2017-01-19-11-10-03-integer.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nFlash will be erased from 0x00000000 to 0x0005ffff...\nCompressed 390412 bytes to 250019...\nWriting at 0x00000000... (6 %)\nWriting at 0x00005368... (12 %)\nWriting at 0x0001470b... (18 %)\nWriting at 0x00019e6b... (25 %)\nWriting at 0x0001f781... (31 %)\nWriting at 0x00024ecc... (37 %)\nWriting at 0x0002a753... (43 %)\nWriting at 0x0002f853... (50 %)\nWriting at 0x00034892... (56 %)\nWriting at 0x00039bb9... (62 %)\nWriting at 0x0003ffb1... (68 %)\nWriting at 0x000459cb... (75 %)\nWriting at 0x0004b15e... (81 %)\nWriting at 0x00050a71... (87 %)\nWriting at 0x00056921... (93 %)\nWriting at 0x0005d1b2... (100 %)\nWrote 390412 bytes (250019 compressed) at 0x00000000 in 11.9 seconds (effective 262.1 kbit/s)...\nHash of data verified.\n\nLeaving...\nHard resetting via RTS pin...\n'
Running /Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python /Users/XiNGRZ/Projects/esptool/test/../esptool.py --chip esp32c3 --port /dev/cu.usbserial-21340 --baud 230400 verify_flash 0x0 images/nodemcu-master-7-modules-2017-01-19-11-10-03-integer.bin...
b'esptool.py v3.2-dev\nSerial port /dev/cu.usbserial-21340\nConnecting....\nChip is ESP32-C3 (revision 3)\nFeatures: Wi-Fi\nCrystal is 40MHz\nMAC: 7c:df:a1:c2:22:10\nUploading stub...\nRunning stub...\nStub running...\nChanging baud rate to 230400\nChanged.\nConfiguring flash size...\nVerifying 0x5f50c (390412) bytes @ 0x00000000 in flash against images/nodemcu-master-7-modules-2017-01-19-11-10-03-integer.bin...\n-- verify OK (digest matched)\nHard resetting via RTS pin...\n'
.
======================================================================
ERROR [11.906s]: test_stub_reuse_with_synchronization (__main__.TestStubReuse)
Keep the flasher stub running and reuse it the next time.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/XiNGRZ/Projects/esptool/test/./test_esptool.py", line 482, in test_stub_reuse_with_synchronization
    res = self.run_esptool("--before no_reset flash_id")  # do sync before (without reset it talks to the flasher stub)
  File "/Users/XiNGRZ/Projects/esptool/test/./test_esptool.py", line 145, in run_esptool
    raise e
  File "/Users/XiNGRZ/Projects/esptool/test/./test_esptool.py", line 140, in run_esptool
    output = subprocess.check_output([str(s) for s in cmd], cwd=TEST_DIR, stderr=subprocess.STDOUT)
  File "/usr/local/Cellar/python@3.9/3.9.5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/local/Cellar/python@3.9/3.9.5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/Users/XiNGRZ/.espressif/python_env/idf4.3_py3.9_env/bin/python', '/Users/XiNGRZ/Projects/esptool/test/../esptool.py', '--chip', 'esp32c3', '--port', '/dev/cu.usbserial-21340', '--baud', '230400', '--before', 'no_reset', 'flash_id']' returned non-zero exit status 2.

----------------------------------------------------------------------
Ran 61 tests in 501.180s

FAILED (errors=1, skipped=7)

Generating XML reports...
```