### PR TITLE
Add RTS pin enable action explicitly due to different behavior of USB serial driver under Linux (ESPTOOL-322)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -513,6 +513,7 @@ class ESPLoader(object):
         self._slip_reader = slip_reader(self._port, self.trace)
 
     def sync(self):
+        self._setRTS(True)
         val, _ = self.command(self.ESP_SYNC, b'\x07\x07\x12\x20' + 32 * b'\x55',
                               timeout=SYNC_TIMEOUT)
 


### PR DESCRIPTION
# Fix download fails with esptool and ESP32-C3
Since it's widely known that CH340 does not have a high quality driver under Linux, use some other driver instead is an practical option.

# Description of change
Enable module explicitly before transaction.

### I have tested this change with the following hardware & software combinations:
ESP-C3-32S

With USB-serial converter CH340 driver
https://github.com/juliagoda/CH341SER.git

#### Before the fix
```bash
$ ./esptool.py --chip esp32c3 -p /dev/ttyUSB0 -b 115200 chip_id
esptool.py v3.2-dev
Serial port /dev/ttyUSB0
Connecting......................................

A fatal error occurred: Failed to connect to ESP32-C3: Download mode successfully detected, but getting no sync reply: The serial TX path seems to be down.
For troubleshooting steps visit: https://github.com/espressif/esptool#troubleshooting
```
![20211009-012646-NG-1](https://user-images.githubusercontent.com/16630667/136601386-e4da05e7-8e51-4acb-8cdb-29b50de5af3e.png)

#### After the fix
The esptool works as expected.
```bash
$ ./esptool.py --chip esp32c3 -p /dev/ttyUSB0 -b 115200 chip_id
esptool.py v3.2-dev
Serial port /dev/ttyUSB0
Connecting.....
Chip is ESP32-C3 (revision 3)
Features: Wi-Fi
Crystal is 40MHz
MAC: 00:00:00:00:00:00
Uploading stub...
Running stub...
Stub running...
Warning: ESP32-C3 has no Chip ID. Reading MAC instead.
MAC: 00:00:00:00:00:00
Hard resetting via RTS pin...
```
![20211009-012439-OK-1](https://user-images.githubusercontent.com/16630667/136601418-e6876edb-d85b-43f7-be66-c741a2c55ed2.png)
