### PR TITLE
support for ESP32-S2 ESP32-S3 Flash 32MB..128MB (ESPTOOL-325)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1461,7 +1461,7 @@ class ESP32ROM(ESPLoader):
         '16MB': 0x40,
         '32MB': 0x50,
         '64MB': 0x60,
-        '128MB': 0x70       
+        '128MB': 0x70
     }
 
     BOOTLOADER_FLASH_OFFSET = 0x1000


### PR DESCRIPTION
ESP32-S2 and ESP32-S3
supports up to 1 GB of external flash and RAM
add support for 
- 32MB
- 64MB
- 128MB ( example NOR spiFLASH 1G-BIT W25Q01JVZEIQ Winbond 0xEF 0x40 0x21 )

( i removed the 256MB, 512MB, 1024MB in this pull request and changed title from 32MB..1024MB to 32MB..128MB
as soon we can test 256MB, 512MB and the 1024MB i update with a new Pull Request )   

change small typo in helper --flash-size


I have [tested this change](https://twitter.com/eMbeddedHome/status/1447962041180991489) with the following hardware & software combinations:
Winbond 
NOR spiFLASH 1G-BIT W25Q01JVZEIQ 0x21 )

![image](https://user-images.githubusercontent.com/16070445/137204233-d047fe09-9405-4ae0-9ca3-5a2d12c3918d.png)

ESP32-S2-DevKitC-1
ESP32-S3-DevKitC-1
ESP-IDF v4.4-dev-3235-g3e370c4296-dirty


