### PR TITLE
removed a default mutable argument pitfall (ESPTOOL-344)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -1865,7 +1865,9 @@ class ESP32S2ROM(ESP32ROM):
         return any(p == self.PURPOSE_VAL_XTS_AES256_KEY_1 for p in purposes) \
             and any(p == self.PURPOSE_VAL_XTS_AES256_KEY_2 for p in purposes)
 
-    def uses_usb(self, _cache=[]):
+    def uses_usb(self, _cache=None):
+        if not _cache:
+            _cache = []
         if self.secure_download_mode:
             return False  # can't detect native USB in secure download mode
         if not _cache:
@@ -2033,7 +2035,9 @@ class ESP32S3ROM(ESP32ROM):
         except TypeError:  # Python 3, bitstring elements are already bytes
             return tuple(bitstring)
 
-    def uses_usb(self, _cache=[]):
+    def uses_usb(self, _cache=None):
+        if not _cache:
+            _cache = []
         if self.secure_download_mode:
             return False  # can't detect native USB in secure download mode
         if not _cache:


### PR DESCRIPTION
**The problem**
In Python it usually dangerous to use mutable arguments like dicts or lists as default arguments in methods, as is better explained [here](https://docs.python-guide.org/writing/gotchas/)

**the solution**
This PR applies a simple refactoring to remove a case where a method was created using default a mutable argument