### PR TITLE
WIP: Fix macOS bootloader reset (ESPTOOL-396)

### DIFF
--- a/esptool.py
+++ b/esptool.py
@@ -596,8 +596,6 @@ class ESPLoader(object):
             self._setDTRAndRTS(True, True)
             self._setDTRAndRTS(False, True) # IO0=HIGH & EN=LOW, chip in reset
             time.sleep(0.1)
-            if extra_delay:
-                time.sleep(1.2)
             self._setDTRAndRTS(True, False) # IO0=LOW & # EN=HIGH, chip out of reset
             time.sleep(delay)
             self._setDTRAndRTS(False, False) # IO0=HIGH, done

--- a/esptool.py
+++ b/esptool.py
@@ -588,6 +588,8 @@ class ESPLoader(object):
             self._setDTR(False)  # IO0=HIGH
             self._setRTS(True)   # EN=LOW, chip in reset
             time.sleep(0.1)
+            if extra_delay:
+                time.sleep(1.2)
             self._setDTR(True)   # IO0=LOW
             self._setRTS(False)  # EN=HIGH, chip out of reset
             time.sleep(delay)


### PR DESCRIPTION
# Description of change

This change adds back the delay present in esptool prior to v.3.2. It has been removed in the following commit: https://github.com/espressif/esptool/commit/2d72f56ce6b6103d908194f6d4237a2032ce9b89

# This change fixes the following bug(s):

At least for me it fixed the problems mentioned in my comment: https://github.com/espressif/esptool/issues/712#issuecomment-1021675247

# I have tested this change with the following hardware & software combinations:

- MacBook Pro M1-Max
- Mac OS 12.1
- ESP32-D0WDQ6 (revision 1)

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

Not run. Not familiar with that.