### PR TITLE
current script is located at __file__, not sys.executable (ESPTOOL-456)

### DIFF
--- a/espefuse.py
+++ b/espefuse.py
@@ -20,7 +20,7 @@ import sys
 
 with contextlib.suppress(ValueError):
     if os.name != "nt":
-        sys.path.remove(os.path.dirname(sys.executable))
+        sys.path.remove(os.path.realpath(os.path.dirname(__file__)))
 
 import espefuse
 

--- a/espsecure.py
+++ b/espsecure.py
@@ -20,7 +20,7 @@ import sys
 
 with contextlib.suppress(ValueError):
     if os.name != "nt":
-        sys.path.remove(os.path.dirname(sys.executable))
+        sys.path.remove(os.path.realpath(os.path.dirname(__file__)))
 
 import espsecure
 

--- a/esptool.py
+++ b/esptool.py
@@ -19,7 +19,7 @@ import sys
 
 with contextlib.suppress(ValueError):
     if os.name != "nt":
-        sys.path.remove(os.path.dirname(sys.executable))
+        sys.path.remove(os.path.realpath(os.path.dirname(__file__)))
 
 import esptool
 


### PR DESCRIPTION
# Description of change
In order to remove the current script directory from `sys.path`, we have to remove `os.path.dirname(__file__)`. `sys.executable` is the location of the Python interpreter, not the script.

# I have tested this change with the following hardware & software combinations:
NixOS, no hardware needed

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:
```
Running image generation tests...
.............
----------------------------------------------------------------------
Ran 13 tests in 2.788s

OK
Running espsecure tests...
Using espsecure 4.0 at /nix/store/gj41j6vrf4w7cwmsg064c8qigp5xfz2c-esptool-4.0/lib/python3.9/site-packages/espsecure/__init__.py
.....................
----------------------------------------------------------------------
Ran 21 tests in 2.036s

OK
........
----------------------------------------------------------------------
Ran 8 tests in 1.755s

OK
Running python modules tests...
.
----------------------------------------------------------------------
Ran 1 test in 0.003s

OK
```
