### PR TITLE
Gracefully finish esptool when device is not detected on given port (ESPTOOL-468)

### DIFF
--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -243,7 +243,10 @@ class ESPLoader(object):
         self.stub_is_disabled = False
 
         if isinstance(port, str):
-            self._port = serial.serial_for_url(port)
+            try:
+                self._port = serial.serial_for_url(port)
+            except serial.serialutil.SerialException:
+                raise FatalError(f"Could not open {port}, the port doesn't exist")
         else:
             self._port = port
         self._slip_reader = slip_reader(self._port, self.trace)


### PR DESCRIPTION
# Description of change

Silence the traceback that was being printed in such cases,
provide a user-friendly message and finish the app with sys.exit()
instead.

# This change fixes the following bug(s):

#750 

# I have tested this change with the following hardware & software combinations:

Fedora Linux 35 - ESP8266

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

`test_imagegen.py` - OK
`./test_esptool.py /dev/ttyUSB2 esp8266 460800`
I've got this error but I think it's unrelated to my changes.

```
ERROR [6.734s]: test_stub_reuse_with_synchronization (__main__.TestStubReuse)
Keep the flasher stub running and reuse it the next time.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ksurma/dev/esptool/test/./test_esptool.py", line 603, in test_stub_reuse_with_synchronization
    res = self.run_esptool(
  File "/home/ksurma/dev/esptool/test/./test_esptool.py", line 199, in run_esptool
    raise e
  File "/home/ksurma/dev/esptool/test/./test_esptool.py", line 192, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib64/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib64/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/ksurma/dev/esptool/venv/bin/python', '/home/ksurma/dev/esptool/test/../esptool/__init__.py', '--chip', 'esp8266', '--port', '/dev/ttyUSB0', '--baud', '460800', '--before', 'no_reset', 'flash_id']' returned non-zero exit status 2.
```

