### PR TITLE
Fix ESP32-S3 USB console detection (ESPTOOL-485)

### DIFF
--- a/esptool/targets/esp32s3.py
+++ b/esptool/targets/esp32s3.py
@@ -76,8 +76,9 @@ class ESP32S3ROM(ESP32ROM):
     PURPOSE_VAL_XTS_AES256_KEY_2 = 3
     PURPOSE_VAL_XTS_AES128_KEY = 4
 
-    UARTDEV_BUF_NO = 0x3FCEF14C  # Variable in ROM .bss which indicates the port in use
-    UARTDEV_BUF_NO_USB = 3  # Value of the above variable indicating that USB is in use
+    UARTDEV_BUF_NO = 0x3FCEF14C  # Variable in ROM .bss with the port in use
+    UARTDEV_BUF_NO_USB_OTG = 3  # Serial via USB-CDC with USB-OTG peripheral
+    UARTDEV_BUF_NO_USB_CDC = 4  # Serial via hardware USB-CDC peripheral
 
     USB_RAM_BLOCK = 0x800  # Max block size USB CDC is used
 
@@ -163,7 +164,9 @@ class ESP32S3ROM(ESP32ROM):
             return False  # can't detect native USB in secure download mode
         if not _cache:
             buf_no = self.read_reg(self.UARTDEV_BUF_NO) & 0xFF
-            _cache.append(buf_no == self.UARTDEV_BUF_NO_USB)
+            _cache.append(
+                buf_no in [self.UARTDEV_BUF_NO_USB_OTG, self.UARTDEV_BUF_NO_USB_CDC]
+            )
         return _cache[0]
 
     def _post_connect(self):


### PR DESCRIPTION
# Description of change
Fix detection of integrated USB for bootloading the ESP32-S3.

# This change fixes the following bug(s):
https://github.com/espressif/esptool/issues/756

# I have tested this change with the following hardware & software combinations:
Ubuntu Linux 22.04, Adafruit Feather ESP32-S3 TFT, arduino-esp under platformio

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

Various failures, BUT these failures also happen without this change! I think they're mostly related to the serial port disappearing/reappearing during entry to the bootloader. Let me know if you think I should dive into these.

```
======================================================================
ERROR [12.259s]: test_chip_erase (__main__.TestErase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 627, in test_chip_erase
    self.run_esptool("erase_flash")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'erase_flash']' returned non-zero exit status 1.

======================================================================
ERROR [0.055s]: test_large_region_erase (__main__.TestErase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 644, in test_large_region_erase
    self.run_esptool("erase_region 0x0 0x100000")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'erase_region', '0x0', '0x100000']' returned non-zero exit status 2.

======================================================================
ERROR [0.048s]: test_region_erase (__main__.TestErase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 632, in test_region_erase
    self.run_esptool("write_flash 0x10000 images/one_kb.bin")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'write_flash', '0x10000', 'images/one_kb.bin']' returned non-zero exit status 2.

======================================================================
ERROR [0.043s]: test_flash_id (__main__.TestFlashDetection)
Test manufacturer and device response of flash detection.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 590, in test_flash_id
    res = self.run_esptool("flash_id")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'flash_id']' returned non-zero exit status 2.

======================================================================
ERROR [0.043s]: test_flash_size_keep (__main__.TestFlashSizes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 582, in test_flash_size_keep
    self.run_esptool("write_flash -fs keep %d %s" % (offset, image))
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'write_flash', '-fs', 'keep', '0', 'images/bootloader_esp32s3.bin']' returned non-zero exit status 2.

======================================================================
ERROR [0.042s]: test_high_offset (__main__.TestFlashSizes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 521, in test_high_offset
    self.run_esptool("write_flash -fs 4MB 0x300000 images/one_kb.bin")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'write_flash', '-fs', '4MB', '0x300000', 'images/one_kb.bin']' returned non-zero exit status 2.

======================================================================
ERROR [0.043s]: test_high_offset_no_compression (__main__.TestFlashSizes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 525, in test_high_offset_no_compression
    self.run_esptool("write_flash -u -fs 4MB 0x300000 images/one_kb.bin")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'write_flash', '-u', '-fs', '4MB', '0x300000', 'images/one_kb.bin']' returned non-zero exit status 2.

======================================================================
ERROR [0.042s]: test_large_image (__main__.TestFlashSizes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 529, in test_large_image
    self.run_esptool("write_flash -fs 4MB 0x280000 images/one_mb.bin")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'write_flash', '-fs', '4MB', '0x280000', 'images/one_mb.bin']' returned non-zero exit status 2.

======================================================================
ERROR [0.042s]: test_large_no_compression (__main__.TestFlashSizes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 533, in test_large_no_compression
    self.run_esptool("write_flash -u -fs 4MB 0x280000 images/one_mb.bin")
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--chip', 'esp32s3', '--port', '/dev/ttyACM0', '--baud', '230400', 'write_flash', '-u', '-fs', '4MB', '0x280000', 'images/one_mb.bin']' returned non-zero exit status 2.

======================================================================
ERROR [0.042s]: test_auto_detect (__main__.TestVirtualPort)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 899, in test_auto_detect
    output = self.run_esptool("chip_id", chip_name=None)
  File "/home/egnor/source/esptool/test/test_esptool.py", line 198, in run_esptool
    raise e
  File "/home/egnor/source/esptool/test/test_esptool.py", line 191, in run_esptool
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/egnor/source/esptool/python_venv/bin/python', '/home/egnor/source/esptool/test/../esptool/__init__.py', '--port', '/dev/ttyACM0', '--baud', '230400', 'chip_id']' returned non-zero exit status 2.

======================================================================
ERROR [10.016s]: test_auto_detect_virtual_port (__main__.TestVirtualPort)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 909, in test_auto_detect_virtual_port
    with ESPRFC2217Server() as server:
  File "/home/egnor/source/esptool/test/test_esptool.py", line 111, in __init__
    self.wait_for_server_starts(attempts_count=5)
  File "/home/egnor/source/esptool/test/test_esptool.py", line 145, in wait_for_server_starts
    raise Exception("Server not started successfully!")
Exception: Server not started successfully!

======================================================================
ERROR [10.018s]: test_highspeed_flash_virtual_port (__main__.TestVirtualPort)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 920, in test_highspeed_flash_virtual_port
    with ESPRFC2217Server() as server:
  File "/home/egnor/source/esptool/test/test_esptool.py", line 111, in __init__
    self.wait_for_server_starts(attempts_count=5)
  File "/home/egnor/source/esptool/test/test_esptool.py", line 145, in wait_for_server_starts
    raise Exception("Server not started successfully!")
Exception: Server not started successfully!

======================================================================
FAIL [0.043s]: test_write_no_compression_past_end_fails (__main__.TestFlashSizes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/egnor/source/esptool/test/test_esptool.py", line 550, in test_write_no_compression_past_end_fails
    self.assertIn("File images/one_kb.bin", output)
AssertionError: 'File images/one_kb.bin' not found in "esptool.py v4.2-dev\nSerial port /dev/ttyACM0\n\nA fatal error occurred: Could not open /dev/ttyACM0, the port doesn't exist\n"

----------------------------------------------------------------------
Ran 74 tests in 288.550s

FAILED (failures=1, errors=12, skipped=8)

Generating XML reports...
```