### PR TITLE
delay 0.1s for hardware_reset() with rts for s2/s3

### DIFF
--- a/esptool/targets/esp32s2.py
+++ b/esptool/targets/esp32s2.py
@@ -268,6 +268,7 @@ class ESP32S2ROM(ESP32ROM):
             self._setRTS(False)
             time.sleep(0.2)
         else:
+            time.sleep(0.1)
             self._setRTS(False)
 
 

--- a/esptool/targets/esp32s3.py
+++ b/esptool/targets/esp32s3.py
@@ -208,6 +208,7 @@ class ESP32S3ROM(ESP32ROM):
             self._setRTS(False)
             time.sleep(0.2)
         else:
+            time.sleep(0.1)
             self._setRTS(False)
 
 


### PR DESCRIPTION
# Description of change

This change add 0.1s delay between setRTS() in hard_reset() for S2 and S3 to fix the following issue: 

Adafruit is making an BT classic UART board using ESP32 SPP, basically ESP32 version of this product https://www.adafruit.com/product/1588 , mentioned here https://youtu.be/2vom0VfjCDY?t=85 . We are able to use this to program another esp32, c3, s2 and s3 via BT. However, after programmed, it has an issue to do **"Hard resetting via RTS pin..."**. 

I have done an extensive testing and even enforce an minium RTR active walkaround in the board firmware. However, it seems that the RTS toggle without delay is too fast, the second setRTS(False) occurs on the host side before events sending via BT. And host driver (on Linux) probably either decide not to send the toggle and/or the ESP32's rfcomm does not register modem signal changed. The result is RTS is not toggle on target side.

Note: I have tested that even an 0.05 or 0.01 delay is enough to get it work. Though 0.1 is used to be consistent with normal esp32. If you think 0.1 is too long, we can get it down to 0.01s

# I have tested this change with the following hardware & software combinations:

- Operating system(s): Ubuntu 22.04
- development board name(s): esp32s2 & esp32s3 devkit

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

```
$ python test/test_imagegen.py 
Running image generation tests...
..............
----------------------------------------------------------------------
Ran 14 tests in 0.995s

OK

$ python test/test_esptool.py /dev/ttyUSB0 esp32s2

Ran 62 tests in 748.922s

OK (skipped=8)

$ python test/test_esptool.py /dev/ttyUSB0 esp32s3

Ran 62 tests in 749.465s

OK (skipped=8)
```
The details of hw test_esptool.py can be found here 
[test_esptool_esp32s2.txt](https://github.com/espressif/esptool/files/9266411/test_esptool_esp32s2.txt)
[test_esptool_esp32s3.txt](https://github.com/espressif/esptool/files/9266413/test_esptool_esp32s3.txt)

@ladyada 