### PR TITLE
Update basic-options readme with more linux instructions (ESPTOOL-497)

### DIFF
--- a/docs/en/esptool/basic-options.rst
+++ b/docs/en/esptool/basic-options.rst
@@ -23,7 +23,8 @@ Serial Port
 If using Cygwin or WSL on Windows, you have to convert the Windows-style name into a Unix-style path (``COM1`` -> ``/dev/ttyS0``, and so on). (This is not necessary if using ESP-IDF with the supplied Windows MSYS2 environment,
 this environment uses a native Windows Python which accepts COM ports as-is.)
 
-In Linux, the current user may not have access to serial ports and a "Permission Denied" error will appear. On most Linux distributions, the solution is to add the user to the ``dialout`` group with a command like ``sudo usermod -a -G dialout <USERNAME>``.
+In Linux, the current user may not have access to serial ports and a "Permission Denied" or "port doesn't exist" error may appear. On most Linux distributions, the solution is to add the user to the ``dialout`` group (check e.g. `ls -l /dev/ttyUSB0` to find the group) with a command like ``sudo usermod -a -G dialout <USERNAME>``.
+You can call `su - $USER` to have the new group picked-up without having to log out/ in again.
 Check your Linux distribution's documentation for more information.
 
 Baud Rate


### PR DESCRIPTION
# Description of change

Improve documentation for getting set-up on linux.

# I have tested this change with the following hardware & software combinations:

Ubuntu 18.04.6 LTS
ESP32-D0WDQ6-V3 (revision 3)