### PR TITLE
Support for 64MB+ mbit flashes (ESPTOOL-500)

### DIFF
--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -58,7 +58,9 @@ DETECTED_FLASH_SIZES = {
     0x18: "16MB",
     0x19: "32MB",
     0x1A: "64MB",
+    0x20: "64MB",
     0x21: "128MB",
+    0x22: "256MB",
 }
 
 FLASH_MODES = {"qio": 0, "qout": 1, "dio": 2, "dout": 3}


### PR DESCRIPTION
This change adds support for 64MB (512mbit) and above flashes which (strangely) eschew the convention that goes from 0x12 - 0x19 for 256KB - 32MB flashes and jumps to 0x20 - 0x22 for 64MB - 256MB flashes. This pattern has been confirmed for Micron, Winbond, and Gigadevice flashes.

See related IDF PRs for further discussion: https://github.com/espressif/esp-idf/pull/9381 https://github.com/espressif/esp-idf/pull/9566

I have tested this change with `W25Q512JVEQ` chips (64MB) on ESP32-S3.