### PR TITLE
espsecure: Run AES-XTS encryption in O(n) instead of O(n^2) time complexity (ESPTOOL-523)

### DIFF
--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -1050,7 +1050,7 @@ def _flash_encryption_operation_aes_xts(
 
     inblocks = _split_blocks(indata, 0x80)  # split into 1024 bit blocks
 
-    output = b""
+    output = []
     for inblock in inblocks:  # for each block
         tweak = struct.pack("<I", (flash_address & ~0x7F)) + (b"\x00" * 12)
         flash_address += 0x80  # for next block
@@ -1065,7 +1065,9 @@ def _flash_encryption_operation_aes_xts(
 
         inblock = inblock[::-1]  # reverse input
         outblock = encryptor.update(inblock)  # standard algo
-        output += outblock[::-1]  # reverse output
+        output.append(outblock[::-1])  # reverse output
+
+    output = b"".join(output)
 
     # undo any padding we applied to the input
     if pad_right != 0:
@@ -1087,9 +1089,10 @@ def _flash_encryption_operation_aes_xts(
 def _split_blocks(text, block_len=16):
     """Take a bitstring, split it into chunks of "block_len" each"""
     assert len(text) % block_len == 0
-    while len(text) > 0:
-        yield text[0:block_len]
-        text = text[block_len:]
+    pos = 0
+    while pos < len(text):
+        yield text[pos : pos + block_len]
+        pos = pos + block_len
 
 
 def decrypt_flash_data(args):


### PR DESCRIPTION
# Description of change

The espsecure tool is currently very slow at encrypting large files with AES-XTS. The code currently runs in $O(n^2)$ time complexity, which is very bad.

Some timing I did on my computer:

| Size  | Time |
| ------------- | ------------- |
| 1 MByte | 0.514s  |
| 2 MByte | 1.973s  |
| 4 MByte | 8.806s |
| 8 MByte | 37.318s |

With this patch, these are the new results:

| Size  | Time |
| ------------- | ------------- |
| 1 MByte | 0.146s  |
| 2 MByte | 0.228s  |
| 4 MByte | 0.391s |
| 8 MByte | 0.572s |

# I have run the esptool.py automated integration tests with this change. The results were:

```
.......................
----------------------------------------------------------------------
Ran 23 tests in 2.970s

OK
```