### PR TITLE
[backport] fix(espefuse): Fix compatibility with Bitstring>=4 (ESPTOOL-552)

### DIFF
--- a/espressif/efuse/base_fields.py
+++ b/espressif/efuse/base_fields.py
@@ -11,7 +11,7 @@ import binascii
 import re
 import sys
 
-from bitstring import BitArray, BitString, CreationError
+from bitstring import BitArray, BitStream, CreationError
 
 import esptool
 
@@ -125,14 +125,14 @@ class EfuseBlockBase(EfuseProtectBase):
         self.len = param.len
         self.key_purpose_name = param.key_purpose
         bit_block_len = self.get_block_len() * 8
-        self.bitarray = BitString(bit_block_len)
+        self.bitarray = BitStream(bit_block_len)
         self.bitarray.set(0)
-        self.wr_bitarray = BitString(bit_block_len)
+        self.wr_bitarray = BitStream(bit_block_len)
         self.wr_bitarray.set(0)
         self.fail = False
         self.num_errors = 0
         if self.id == 0:
-            self.err_bitarray = BitString(bit_block_len)
+            self.err_bitarray = BitStream(bit_block_len)
             self.err_bitarray.set(0)
         else:
             self.err_bitarray = None
@@ -263,7 +263,7 @@ class EfuseBlockBase(EfuseProtectBase):
         # in reg format     = [3][2][1][0] ... [N][][][]    (as it will be in the device)
         # in bitstring      = [N] ... [2][1][0]             (to get a correct bitstring need to reverse new_data)
         # *[x] - means a byte.
-        data = BitString(bytes=new_data[::-1], length=len(new_data) * 8)
+        data = BitStream(bytes=new_data[::-1], length=len(new_data) * 8)
         if self.parent.debug:
             print("\twritten : {} ->\n\tto write: {}".format(self.get_bitstring(), data))
         self.wr_bitarray.overwrite(self.wr_bitarray | data, pos=0)
@@ -451,7 +451,7 @@ class EfuseFieldBase(EfuseProtectBase):
             field_len = int(re.search(r'\d+', self.efuse_type).group())
             if self.efuse_type.startswith("bytes"):
                 field_len *= 8
-        self.bitarray = BitString(field_len)
+        self.bitarray = BitStream(field_len)
         self.bit_len = field_len
         self.bitarray.set(0)
         self.update(self.parent.blocks[self.block].bitarray)

--- a/espressif/efuse/base_operations.py
+++ b/espressif/efuse/base_operations.py
@@ -11,7 +11,7 @@ import argparse
 import json
 import sys
 
-from bitstring import BitString
+from bitstring import BitStream
 
 import esptool
 
@@ -366,7 +366,7 @@ def burn_bit(esp, efuses, args):
     efuses.force_write_always = args.force_write_always
     num_block = efuses.get_index_block_by_name(args.block)
     block = efuses.blocks[num_block]
-    data_block = BitString(block.get_block_len() * 8)
+    data_block = BitStream(block.get_block_len() * 8)
     data_block.set(0)
     try:
         data_block.set(True, args.bit_number)

--- a/espressif/efuse/emulate_efuse_controller_base.py
+++ b/espressif/efuse/emulate_efuse_controller_base.py
@@ -9,7 +9,13 @@ from __future__ import division, print_function
 
 import re
 
-from bitstring import BitString
+from bitstring import BitStream
+
+try:
+    FileNotFoundError
+except NameError:
+    # Python 2.7 compatibility
+    FileNotFoundError = IOError
 
 
 class EmulateEfuseControllerBase(object):
@@ -28,15 +34,18 @@ class EmulateEfuseControllerBase(object):
         self.efuse_file = efuse_file
         if self.efuse_file:
             try:
-                self.mem = BitString(open(self.efuse_file, 'a+b'), length=self.REGS.EFUSE_MEM_SIZE * 8)
-            except ValueError:
+                self.mem = BitStream(
+                    bytes=open(self.efuse_file, "rb").read(),
+                    length=self.REGS.EFUSE_MEM_SIZE * 8,
+                )
+            except (ValueError, FileNotFoundError):
                 # the file is empty or does not fit the length.
-                self.mem = BitString(length=self.REGS.EFUSE_MEM_SIZE * 8)
+                self.mem = BitStream(length=self.REGS.EFUSE_MEM_SIZE * 8)
                 self.mem.set(0)
                 self.mem.tofile(open(self.efuse_file, 'a+b'))
         else:
             # efuse_file is not provided it means we do not want to keep the result of efuse operations
-            self.mem = BitString(self.REGS.EFUSE_MEM_SIZE * 8)
+            self.mem = BitStream(self.REGS.EFUSE_MEM_SIZE * 8)
             self.mem.set(0)
 
     """ esptool method start >> """
@@ -146,7 +155,7 @@ class EmulateEfuseControllerBase(object):
         # checks fields which have the write protection bit.
         # if the write protection bit is set then we need to protect that area from changes.
         write_disable_bit = self.read_field("WR_DIS", bitstring=False)
-        mask_wr_data = BitString(len(wr_data))
+        mask_wr_data = BitStream(len(wr_data))
         mask_wr_data.set(0)
         blk = self.Blocks.get(self.Blocks.BLOCKS[num_blk])
         if blk.write_disable_bit is not None and write_disable_bit & (1 << blk.write_disable_bit):
@@ -179,7 +188,7 @@ class EmulateEfuseControllerBase(object):
                         raw_data = self.read_field(field.name)
                         raw_data.set(0)
                         block.pos = block.length - (field.word * 32 + field.pos + raw_data.length)
-                        block.overwrite(BitString(raw_data.length))
+                        block.overwrite(BitStream(raw_data.length))
             self.overwrite_mem_from_block(blk, block)
 
     def clean_mem(self):

--- a/espressif/efuse/esp32c2/emulate_efuse_controller.py
+++ b/espressif/efuse/esp32c2/emulate_efuse_controller.py
@@ -7,7 +7,7 @@
 
 from __future__ import division, print_function
 
-from bitstring import BitString
+from bitstring import BitStream
 
 import reedsolo
 
@@ -125,5 +125,5 @@ class EmulateEfuseController(EmulateEfuseControllerBase):
                         raw_data = self.read_field(field.name)
                         raw_data.set(0)
                         block.pos = block.length - (field.word * 32 + field.pos + raw_data.length)
-                        block.overwrite(BitString(raw_data.length))
+                        block.overwrite(BitStream(raw_data.length))
             self.overwrite_mem_from_block(blk, block)

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,8 @@ setup(
         ],
     },
     install_requires=[
-        'bitstring>=3.1.6,<4',
+        'bitstring>=3.1.6; python_version>="3.7"',
+        'bitstring>=3.1.6,<4; python_version<"3.7"',
         'cryptography>=2.1.4',
         'ecdsa>=0.16.0',
         'pyserial>=3.0',

--- a/test/test_espefuse_host.py
+++ b/test/test_espefuse_host.py
@@ -31,7 +31,7 @@ import tempfile
 import time
 import unittest
 
-from bitstring import BitString
+from bitstring import BitStream
 
 import serial
 
@@ -97,7 +97,7 @@ class EfuseTestCase(unittest.TestCase):
 
     def check_data_block_in_log(self, log, file_path, repeat=1, reverse_order=False, offset=0):
         with open(file_path, 'rb') as f:
-            data = BitString('0x00') * offset + BitString(f)
+            data = BitStream('0x00') * offset + BitStream(f)
             blk = data.readlist("%d*uint:8" % (data.len // 8))
             blk = blk[::-1] if reverse_order else blk
             hex_blk = " ".join("{:02x}".format(num) for num in blk)


### PR DESCRIPTION
This is a request to backport https://github.com/espressif/esptool/commit/ee27a6437576797d5f58c31e1c39f3a232a71df0 to the v3 branch.

I am updating `bitstring` in [nixpkgs](https://github.com/NixOS/nixpkgs) to v4.0.1 and would like to depend on it everywhere. nixpkgs packages both esptool v3 and v4 because (it seems) `esphome` still depends on v3.

Thank you!