### PR TITLE
fix import error if bitstring is larger than 4.0 (ESPTOOL-572)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         ],
     },
     install_requires=[
-        "bitstring>=3.1.6",
+        "bitstring>=3.1.6,<4.0.0",
         "cryptography>=2.1.4",
         "ecdsa>=0.16.0",
         "pyserial>=3.0",


### PR DESCRIPTION
(Please delete any lines which don't apply)

# Description of change

In `setup.py`, locked `bitstring` version under 4.0.0

# This change fixes the following bug(s):

If `bitstring` is >= 4.0.0 (released on 2022/11/16), the scripts using it won't work, reporting an import error.

# I have tested this change with the following hardware & software combinations:

Ubuntu 20.04 LTS, ESP32

# I have run the esptool.py automated integration tests with this change and the above hardware. The results were:

NOTE: I'm using M5Stack atom lite, which has a 41.01MHz crystal. The serial connection is not usable on higher baud rates.

<details><summary>click to expand</summary>

```txt
$ pytest test/test_esptool.py --port /dev/ttyUSB0 --chip esp32 --baud 115200
==================================== test session starts =====================================
platform linux -- Python 3.8.10, pytest-7.2.0, pluggy-1.0.0
rootdir: /
plugins: rerunfailures-10.3
collected 65 items

test/test_esptool.py sss.F....F..F............s...........s..........s....F..s.....RRR [ 96%]
RRF..                                                                                  [100%]

========================================== FAILURES ==========================================
_____________________________ TestFlashing.test_highspeed_flash ______________________________

self = <test_esptool.TestFlashing object at 0x7fba8e397b80>

    def test_highspeed_flash(self):
>       self.run_esptool("write_flash 0x0 images/fifty_kb.bin", baud=921600)

/home/nviditor/projects/esptool/test/test_esptool.py:355:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/nviditor/projects/esptool/test/test_esptool.py:183: in run_esptool
    raise e
/home/nviditor/projects/esptool/test/test_esptool.py:175: in run_esptool
    output = subprocess.check_output(
/usr/lib/python3.8/subprocess.py:415: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

input = None, capture_output = False, timeout = None, check = True
popenargs = (['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', ...],)
kwargs = {'cwd': '/home/nviditor/projects/esptool/test', 'stderr': -2, 'stdout': -1}
process = <subprocess.Popen object at 0x7fba8e34a5b0>
stdout = b'esptool.py v4.5-dev\nSerial port /dev/ttyUSB0\nConnecting.....Traceback (most recent call last):\n  File "/usr/lib/p...loading stub...\nRunning stub...\nStub running...\nChanging baud rate to 921600\nChanged.\nConfiguring flash size...\n'
stderr = None, retcode = 1

    def run(*popenargs,
            input=None, capture_output=False, timeout=None, check=False, **kwargs):
        """Run command with arguments and return a CompletedProcess instance.

        The returned instance will have attributes args, returncode, stdout and
        stderr. By default, stdout and stderr are not captured, and those attributes
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.

        If check is True and the exit code was non-zero, it raises a
        CalledProcessError. The CalledProcessError object will have the return code
        in the returncode attribute, and output & stderr attributes if those streams
        were captured.

        If timeout is given, and the process takes too long, a TimeoutExpired
        exception will be raised.

        There is an optional argument "input", allowing you to
        pass bytes or a string to the subprocess's stdin.  If you use this argument
        you may not also use the Popen constructor's "stdin" argument, as
        it will be used internally.

        By default, all communication is in bytes, and therefore any "input" should
        be bytes, and the stdout and stderr will be bytes. If in text mode, any
        "input" should be a string, and stdout and stderr will be strings decoded
        according to locale encoding, or by "encoding" if set. Text mode is
        triggered by setting any of text, encoding, errors or universal_newlines.

        The other arguments are the same as for the Popen constructor.
        """
        if input is not None:
            if kwargs.get('stdin') is not None:
                raise ValueError('stdin and input arguments may not both be used.')
            kwargs['stdin'] = PIPE

        if capture_output:
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
                raise ValueError('stdout and stderr arguments may not be used '
                                 'with capture_output.')
            kwargs['stdout'] = PIPE
            kwargs['stderr'] = PIPE

        with Popen(*popenargs, **kwargs) as process:
            try:
                stdout, stderr = process.communicate(input, timeout=timeout)
            except TimeoutExpired as exc:
                process.kill()
                if _mswindows:
                    # Windows accumulates the output in a single blocking
                    # read() call run on child threads, with the timeout
                    # being done in a join() on those threads.  communicate()
                    # _after_ kill() is required to collect that and add it
                    # to the exception.
                    exc.stdout, exc.stderr = process.communicate()
                else:
                    # POSIX _communicate already populated the output so
                    # far into the TimeoutExpired exception.
                    process.wait()
                raise
            except:  # Including KeyboardInterrupt, communicate handled that.
                process.kill()
                # We don't call process.wait() as .__exit__ does that for us.
                raise
            retcode = process.poll()
            if check and retcode:
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', '/dev/ttyUSB0', '--baud', '921600', 'write_flash', '0x0', 'images/fifty_kb.bin']' returned non-zero exit status 1.

/usr/lib/python3.8/subprocess.py:516: CalledProcessError
------------------------------------ Captured stdout call ------------------------------------

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port /dev/ttyUSB0 --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port /dev/ttyUSB0
Connecting.....Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 832, in main
    operation_func(esp, args)
  File "/home/nviditor/projects/esptool/esptool/cmds.py", line 322, in write_flash
    if esp.get_secure_boot_enabled():
  File "/home/nviditor/projects/esptool/esptool/targets/esp32.py", line 173, in get_secure_boot_enabled
    efuses = self.read_reg(self.EFUSE_RD_ABS_DONE_REG)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 690, in read_reg
    val, data = self.command(
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration

Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

_________________________ TestFlashing.test_compressed_nostub_flash __________________________

self = <test_esptool.TestFlashing object at 0x7fba8eae6250>

    @pytest.mark.skipif(arg_chip == "esp8266", reason="Added in ESP32")
    def test_compressed_nostub_flash(self):
>       self.run_esptool(
            "--no-stub write_flash -z 0x0 images/sector.bin 0x1000 images/fifty_kb.bin"
        )

/home/nviditor/projects/esptool/test/test_esptool.py:390:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/nviditor/projects/esptool/test/test_esptool.py:183: in run_esptool
    raise e
/home/nviditor/projects/esptool/test/test_esptool.py:175: in run_esptool
    output = subprocess.check_output(
/usr/lib/python3.8/subprocess.py:415: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

input = None, capture_output = False, timeout = None, check = True
popenargs = (['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', ...],)
kwargs = {'cwd': '/home/nviditor/projects/esptool/test', 'stderr': -2, 'stdout': -1}
process = <subprocess.Popen object at 0x7fba8e728040>
stdout = b'esptool.py v4.5-dev\nSerial port /dev/ttyUSB0\nConnecting....\nChip is ESP32-PICO-D4 (revision v1.0)\nFeatures: WiFi...ed 4096 bytes to 4107...\n\nA fatal error occurred: Serial data stream stopped: Possible serial noise or corruption.\n'
stderr = None, retcode = 2

    def run(*popenargs,
            input=None, capture_output=False, timeout=None, check=False, **kwargs):
        """Run command with arguments and return a CompletedProcess instance.

        The returned instance will have attributes args, returncode, stdout and
        stderr. By default, stdout and stderr are not captured, and those attributes
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.

        If check is True and the exit code was non-zero, it raises a
        CalledProcessError. The CalledProcessError object will have the return code
        in the returncode attribute, and output & stderr attributes if those streams
        were captured.

        If timeout is given, and the process takes too long, a TimeoutExpired
        exception will be raised.

        There is an optional argument "input", allowing you to
        pass bytes or a string to the subprocess's stdin.  If you use this argument
        you may not also use the Popen constructor's "stdin" argument, as
        it will be used internally.

        By default, all communication is in bytes, and therefore any "input" should
        be bytes, and the stdout and stderr will be bytes. If in text mode, any
        "input" should be a string, and stdout and stderr will be strings decoded
        according to locale encoding, or by "encoding" if set. Text mode is
        triggered by setting any of text, encoding, errors or universal_newlines.

        The other arguments are the same as for the Popen constructor.
        """
        if input is not None:
            if kwargs.get('stdin') is not None:
                raise ValueError('stdin and input arguments may not both be used.')
            kwargs['stdin'] = PIPE

        if capture_output:
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
                raise ValueError('stdout and stderr arguments may not be used '
                                 'with capture_output.')
            kwargs['stdout'] = PIPE
            kwargs['stderr'] = PIPE

        with Popen(*popenargs, **kwargs) as process:
            try:
                stdout, stderr = process.communicate(input, timeout=timeout)
            except TimeoutExpired as exc:
                process.kill()
                if _mswindows:
                    # Windows accumulates the output in a single blocking
                    # read() call run on child threads, with the timeout
                    # being done in a join() on those threads.  communicate()
                    # _after_ kill() is required to collect that and add it
                    # to the exception.
                    exc.stdout, exc.stderr = process.communicate()
                else:
                    # POSIX _communicate already populated the output so
                    # far into the TimeoutExpired exception.
                    process.wait()
                raise
            except:  # Including KeyboardInterrupt, communicate handled that.
                process.kill()
                # We don't call process.wait() as .__exit__ does that for us.
                raise
            retcode = process.poll()
            if check and retcode:
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', '/dev/ttyUSB0', '--baud', '115200', '--no-stub', 'write_flash', '-z', '0x0', 'images/sector.bin', '0x1000', 'images/fifty_kb.bin']' returned non-zero exit status 2.

/usr/lib/python3.8/subprocess.py:516: CalledProcessError
------------------------------------ Captured stdout call ------------------------------------

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port /dev/ttyUSB0 --baud 115200 --no-stub write_flash -z 0x0 images/sector.bin 0x1000 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Enabling default SPI flash mode...
WARNING: Failed to communicate with the flash chip, read/write operations will fail. Try checking the chip connections or removing any other hardware connected to IOs.
Configuring flash size...
Flash will be erased from 0x00000000 to 0x00000fff...
Flash will be erased from 0x00001000 to 0x0000dfff...
Erasing flash...
Compressed 4096 bytes to 4107...

A fatal error occurred: Serial data stream stopped: Possible serial noise or corruption.

__________________ TestFlashing.test_partition_table_then_bootloader_nostub __________________

self = <test_esptool.TestFlashing object at 0x7fba8eae6640>

    def test_partition_table_then_bootloader_nostub(self):
>       self._test_partition_table_then_bootloader("--no-stub write_flash --force")

/home/nviditor/projects/esptool/test/test_esptool.py:410:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/nviditor/projects/esptool/test/test_esptool.py:397: in _test_partition_table_then_bootloader
    self.run_esptool(args + " 0x4000 images/partitions_singleapp.bin")
/home/nviditor/projects/esptool/test/test_esptool.py:183: in run_esptool
    raise e
/home/nviditor/projects/esptool/test/test_esptool.py:175: in run_esptool
    output = subprocess.check_output(
/usr/lib/python3.8/subprocess.py:415: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

input = None, capture_output = False, timeout = None, check = True
popenargs = (['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', ...],)
kwargs = {'cwd': '/home/nviditor/projects/esptool/test', 'stderr': -2, 'stdout': -1}
process = <subprocess.Popen object at 0x7fba8e3574c0>
stdout = b'esptool.py v4.5-dev\nSerial port /dev/ttyUSB0\nConnecting....\nChip is ESP32-PICO-D4 (revision v1.0)\nFeatures: WiFi...fff...\nErasing flash...\n\nA fatal error occurred: Serial data stream stopped: Possible serial noise or corruption.\n'
stderr = None, retcode = 2

    def run(*popenargs,
            input=None, capture_output=False, timeout=None, check=False, **kwargs):
        """Run command with arguments and return a CompletedProcess instance.

        The returned instance will have attributes args, returncode, stdout and
        stderr. By default, stdout and stderr are not captured, and those attributes
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.

        If check is True and the exit code was non-zero, it raises a
        CalledProcessError. The CalledProcessError object will have the return code
        in the returncode attribute, and output & stderr attributes if those streams
        were captured.

        If timeout is given, and the process takes too long, a TimeoutExpired
        exception will be raised.

        There is an optional argument "input", allowing you to
        pass bytes or a string to the subprocess's stdin.  If you use this argument
        you may not also use the Popen constructor's "stdin" argument, as
        it will be used internally.

        By default, all communication is in bytes, and therefore any "input" should
        be bytes, and the stdout and stderr will be bytes. If in text mode, any
        "input" should be a string, and stdout and stderr will be strings decoded
        according to locale encoding, or by "encoding" if set. Text mode is
        triggered by setting any of text, encoding, errors or universal_newlines.

        The other arguments are the same as for the Popen constructor.
        """
        if input is not None:
            if kwargs.get('stdin') is not None:
                raise ValueError('stdin and input arguments may not both be used.')
            kwargs['stdin'] = PIPE

        if capture_output:
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
                raise ValueError('stdout and stderr arguments may not be used '
                                 'with capture_output.')
            kwargs['stdout'] = PIPE
            kwargs['stderr'] = PIPE

        with Popen(*popenargs, **kwargs) as process:
            try:
                stdout, stderr = process.communicate(input, timeout=timeout)
            except TimeoutExpired as exc:
                process.kill()
                if _mswindows:
                    # Windows accumulates the output in a single blocking
                    # read() call run on child threads, with the timeout
                    # being done in a join() on those threads.  communicate()
                    # _after_ kill() is required to collect that and add it
                    # to the exception.
                    exc.stdout, exc.stderr = process.communicate()
                else:
                    # POSIX _communicate already populated the output so
                    # far into the TimeoutExpired exception.
                    process.wait()
                raise
            except:  # Including KeyboardInterrupt, communicate handled that.
                process.kill()
                # We don't call process.wait() as .__exit__ does that for us.
                raise
            retcode = process.poll()
            if check and retcode:
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', '/dev/ttyUSB0', '--baud', '115200', '--no-stub', 'write_flash', '--force', '0x4000', 'images/partitions_singleapp.bin']' returned non-zero exit status 2.

/usr/lib/python3.8/subprocess.py:516: CalledProcessError
------------------------------------ Captured stdout call ------------------------------------

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port /dev/ttyUSB0 --baud 115200 --no-stub write_flash --force 0x4000 images/partitions_singleapp.bin...
esptool.py v4.5-dev
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Enabling default SPI flash mode...
WARNING: Failed to communicate with the flash chip, read/write operations will fail. Try checking the chip connections or removing any other hardware connected to IOs.
Configuring flash size...
Flash will be erased from 0x00004000 to 0x00004fff...
Erasing flash...

A fatal error occurred: Serial data stream stopped: Possible serial noise or corruption.

____________________ TestKeepImageSettings.test_detect_size_changes_size _____________________

self = <test_esptool.TestKeepImageSettings object at 0x7fba8eb121f0>

    def test_detect_size_changes_size(self):
        self.run_esptool(
            f"write_flash -fs detect {self.flash_offset:#x} {self.BL_IMAGE}"
        )
>       readback = self.readback(self.flash_offset, 8)

/home/nviditor/projects/esptool/test/test_esptool.py:737:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/nviditor/projects/esptool/test/test_esptool.py:214: in readback
    self.run_esptool(
/home/nviditor/projects/esptool/test/test_esptool.py:183: in run_esptool
    raise e
/home/nviditor/projects/esptool/test/test_esptool.py:175: in run_esptool
    output = subprocess.check_output(
/usr/lib/python3.8/subprocess.py:415: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

input = None, capture_output = False, timeout = None, check = True
popenargs = (['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', ...],)
kwargs = {'cwd': '/home/nviditor/projects/esptool/test', 'stderr': -2, 'stdout': -1}
process = <subprocess.Popen object at 0x7fba8e2d9c40>
stdout = b'esptool.py v4.5-dev\nSerial port /dev/ttyUSB0\nConnecting.....\nChip is ESP32-PICO-D4 (revision v1.0)\nFeatures: WiF...rrno 5] Input/output error\nRead 8 bytes at 0x00001000 in 0.0 seconds (2.0 kbit/s)...\nHard resetting via RTS pin...\n'
stderr = None, retcode = 1

    def run(*popenargs,
            input=None, capture_output=False, timeout=None, check=False, **kwargs):
        """Run command with arguments and return a CompletedProcess instance.

        The returned instance will have attributes args, returncode, stdout and
        stderr. By default, stdout and stderr are not captured, and those attributes
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.

        If check is True and the exit code was non-zero, it raises a
        CalledProcessError. The CalledProcessError object will have the return code
        in the returncode attribute, and output & stderr attributes if those streams
        were captured.

        If timeout is given, and the process takes too long, a TimeoutExpired
        exception will be raised.

        There is an optional argument "input", allowing you to
        pass bytes or a string to the subprocess's stdin.  If you use this argument
        you may not also use the Popen constructor's "stdin" argument, as
        it will be used internally.

        By default, all communication is in bytes, and therefore any "input" should
        be bytes, and the stdout and stderr will be bytes. If in text mode, any
        "input" should be a string, and stdout and stderr will be strings decoded
        according to locale encoding, or by "encoding" if set. Text mode is
        triggered by setting any of text, encoding, errors or universal_newlines.

        The other arguments are the same as for the Popen constructor.
        """
        if input is not None:
            if kwargs.get('stdin') is not None:
                raise ValueError('stdin and input arguments may not both be used.')
            kwargs['stdin'] = PIPE

        if capture_output:
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
                raise ValueError('stdout and stderr arguments may not be used '
                                 'with capture_output.')
            kwargs['stdout'] = PIPE
            kwargs['stderr'] = PIPE

        with Popen(*popenargs, **kwargs) as process:
            try:
                stdout, stderr = process.communicate(input, timeout=timeout)
            except TimeoutExpired as exc:
                process.kill()
                if _mswindows:
                    # Windows accumulates the output in a single blocking
                    # read() call run on child threads, with the timeout
                    # being done in a join() on those threads.  communicate()
                    # _after_ kill() is required to collect that and add it
                    # to the exception.
                    exc.stdout, exc.stderr = process.communicate()
                else:
                    # POSIX _communicate already populated the output so
                    # far into the TimeoutExpired exception.
                    process.wait()
                raise
            except:  # Including KeyboardInterrupt, communicate handled that.
                process.kill()
                # We don't call process.wait() as .__exit__ does that for us.
                raise
            retcode = process.poll()
            if check and retcode:
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', '/dev/ttyUSB0', '--baud', '115200', '--before', 'default_reset', 'read_flash', '4096', '8', '/tmp/tmps68hw3kr']' returned non-zero exit status 1.

/usr/lib/python3.8/subprocess.py:516: CalledProcessError
------------------------------------ Captured stdout call ------------------------------------

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port /dev/ttyUSB0 --baud 115200 write_flash -fs detect 0x1000 images/bootloader_esp32.bin...
esptool.py v4.5-dev
Serial port /dev/ttyUSB0
Connecting....
Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Configuring flash size...
Auto-detected Flash size: 4MB
Flash will be erased from 0x00001000 to 0x00002fff...
Flash params set to 0x0220
Compressed 7888 bytes to 4535...
Writing at 0x00001000... (100 %)
Wrote 7888 bytes (4535 compressed) at 0x00001000 in 0.5 seconds (effective 118.7 kbit/s)...
Hash of data verified.

Leaving...
Hard resetting via RTS pin...


Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port /dev/ttyUSB0 --baud 115200 --before default_reset read_flash 4096 8 /tmp/tmps68hw3kr...
esptool.py v4.5-dev
Serial port /dev/ttyUSB0
Connecting.....
Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
8 (100 %)
8 (100 %)
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 845, in main
    esp.hard_reset()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 1388, in hard_reset
    self._setRTS(False)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 453, in _setRTS
    self._port.setRTS(state)
  File "/home/nviditor/projects/esptool/.venv/lib/python3.8/site-packages/serial/serialutil.py", line 600, in setRTS
    self.rts = value
  File "/home/nviditor/projects/esptool/.venv/lib/python3.8/site-packages/serial/serialutil.py", line 463, in rts
    self._update_rts_state()
  File "/home/nviditor/projects/esptool/.venv/lib/python3.8/site-packages/serial/serialposix.py", line 708, in _update_rts_state
    fcntl.ioctl(self.fd, TIOCMBIC, TIOCM_RTS_str)
OSError: [Errno 5] Input/output error
Read 8 bytes at 0x00001000 in 0.0 seconds (2.0 kbit/s)...
Hard resetting via RTS pin...

_____________________ TestVirtualPort.test_highspeed_flash_virtual_port ______________________

self = <test_esptool.TestVirtualPort object at 0x7fba8eb1c8b0>

    def test_highspeed_flash_virtual_port(self):
        with ESPRFC2217Server() as server:
            rfc2217_port = f"rfc2217://localhost:{str(server.port)}?ign_set_control"
>           self.run_esptool(
                "write_flash 0x0 images/fifty_kb.bin",
                baud=921600,
                rfc2217_port=rfc2217_port,
            )

/home/nviditor/projects/esptool/test/test_esptool.py:881:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/home/nviditor/projects/esptool/test/test_esptool.py:183: in run_esptool
    raise e
/home/nviditor/projects/esptool/test/test_esptool.py:175: in run_esptool
    output = subprocess.check_output(
/usr/lib/python3.8/subprocess.py:415: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

input = None, capture_output = False, timeout = None, check = True
popenargs = (['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', ...],)
kwargs = {'cwd': '/home/nviditor/projects/esptool/test', 'stderr': -2, 'stdout': -1}
process = <subprocess.Popen object at 0x7fba8e8136d0>
stdout = b'esptool.py v4.5-dev\nSerial port rfc2217://localhost:52195?ign_set_control\nConnecting...\nDevice PID identification...loading stub...\nRunning stub...\nStub running...\nChanging baud rate to 921600\nChanged.\nConfiguring flash size...\n'
stderr = None, retcode = 1

    def run(*popenargs,
            input=None, capture_output=False, timeout=None, check=False, **kwargs):
        """Run command with arguments and return a CompletedProcess instance.

        The returned instance will have attributes args, returncode, stdout and
        stderr. By default, stdout and stderr are not captured, and those attributes
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them.

        If check is True and the exit code was non-zero, it raises a
        CalledProcessError. The CalledProcessError object will have the return code
        in the returncode attribute, and output & stderr attributes if those streams
        were captured.

        If timeout is given, and the process takes too long, a TimeoutExpired
        exception will be raised.

        There is an optional argument "input", allowing you to
        pass bytes or a string to the subprocess's stdin.  If you use this argument
        you may not also use the Popen constructor's "stdin" argument, as
        it will be used internally.

        By default, all communication is in bytes, and therefore any "input" should
        be bytes, and the stdout and stderr will be bytes. If in text mode, any
        "input" should be a string, and stdout and stderr will be strings decoded
        according to locale encoding, or by "encoding" if set. Text mode is
        triggered by setting any of text, encoding, errors or universal_newlines.

        The other arguments are the same as for the Popen constructor.
        """
        if input is not None:
            if kwargs.get('stdin') is not None:
                raise ValueError('stdin and input arguments may not both be used.')
            kwargs['stdin'] = PIPE

        if capture_output:
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
                raise ValueError('stdout and stderr arguments may not be used '
                                 'with capture_output.')
            kwargs['stdout'] = PIPE
            kwargs['stderr'] = PIPE

        with Popen(*popenargs, **kwargs) as process:
            try:
                stdout, stderr = process.communicate(input, timeout=timeout)
            except TimeoutExpired as exc:
                process.kill()
                if _mswindows:
                    # Windows accumulates the output in a single blocking
                    # read() call run on child threads, with the timeout
                    # being done in a join() on those threads.  communicate()
                    # _after_ kill() is required to collect that and add it
                    # to the exception.
                    exc.stdout, exc.stderr = process.communicate()
                else:
                    # POSIX _communicate already populated the output so
                    # far into the TimeoutExpired exception.
                    process.wait()
                raise
            except:  # Including KeyboardInterrupt, communicate handled that.
                process.kill()
                # We don't call process.wait() as .__exit__ does that for us.
                raise
            retcode = process.poll()
            if check and retcode:
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/python', '-m', 'esptool', '--chip', 'esp32', '--port', 'rfc2217://localhost:52195?ign_set_control', '--baud', '921600', 'write_flash', '0x0', 'images/fifty_kb.bin']' returned non-zero exit status 1.

/usr/lib/python3.8/subprocess.py:516: CalledProcessError
------------------------------------ Captured stdout call ------------------------------------
Server started successfully.

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port rfc2217://localhost:48257?ign_set_control --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port rfc2217://localhost:48257?ign_set_control
Connecting...
Device PID identification is only supported on COM and /dev/ serial ports.
.Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 832, in main
    operation_func(esp, args)
  File "/home/nviditor/projects/esptool/esptool/cmds.py", line 322, in write_flash
    if esp.get_secure_boot_enabled():
  File "/home/nviditor/projects/esptool/esptool/targets/esp32.py", line 173, in get_secure_boot_enabled
    efuses = self.read_reg(self.EFUSE_RD_ABS_DONE_REG)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 690, in read_reg
    val, data = self.command(
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration

Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

----------------------------------- Captured stdout setup ------------------------------------

**************************************************
------------------------------------ Captured stdout call ------------------------------------
Server started successfully.

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port rfc2217://localhost:49609?ign_set_control --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port rfc2217://localhost:49609?ign_set_control
Connecting...
Device PID identification is only supported on COM and /dev/ serial ports.
.Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 832, in main
    operation_func(esp, args)
  File "/home/nviditor/projects/esptool/esptool/cmds.py", line 322, in write_flash
    if esp.get_secure_boot_enabled():
  File "/home/nviditor/projects/esptool/esptool/targets/esp32.py", line 173, in get_secure_boot_enabled
    efuses = self.read_reg(self.EFUSE_RD_ABS_DONE_REG)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 690, in read_reg
    val, data = self.command(
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration

Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

----------------------------------- Captured stdout setup ------------------------------------

**************************************************
------------------------------------ Captured stdout call ------------------------------------
Server started successfully.

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port rfc2217://localhost:49691?ign_set_control --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port rfc2217://localhost:49691?ign_set_control
Connecting...
Device PID identification is only supported on COM and /dev/ serial ports.
....Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 832, in main
    operation_func(esp, args)
  File "/home/nviditor/projects/esptool/esptool/cmds.py", line 322, in write_flash
    if esp.get_secure_boot_enabled():
  File "/home/nviditor/projects/esptool/esptool/targets/esp32.py", line 173, in get_secure_boot_enabled
    efuses = self.read_reg(self.EFUSE_RD_ABS_DONE_REG)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 690, in read_reg
    val, data = self.command(
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration

Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

----------------------------------- Captured stdout setup ------------------------------------

**************************************************
------------------------------------ Captured stdout call ------------------------------------
Server started successfully.

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port rfc2217://localhost:54179?ign_set_control --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port rfc2217://localhost:54179?ign_set_control
Connecting...
Device PID identification is only supported on COM and /dev/ serial ports.
.Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 832, in main
    operation_func(esp, args)
  File "/home/nviditor/projects/esptool/esptool/cmds.py", line 322, in write_flash
    if esp.get_secure_boot_enabled():
  File "/home/nviditor/projects/esptool/esptool/targets/esp32.py", line 173, in get_secure_boot_enabled
    efuses = self.read_reg(self.EFUSE_RD_ABS_DONE_REG)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 690, in read_reg
    val, data = self.command(
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration

Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

----------------------------------- Captured stdout setup ------------------------------------

**************************************************
------------------------------------ Captured stdout call ------------------------------------
Server started successfully.

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port rfc2217://localhost:50047?ign_set_control --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port rfc2217://localhost:50047?ign_set_control
Connecting...
Device PID identification is only supported on COM and /dev/ serial ports.
...Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 832, in main
    operation_func(esp, args)
  File "/home/nviditor/projects/esptool/esptool/cmds.py", line 322, in write_flash
    if esp.get_secure_boot_enabled():
  File "/home/nviditor/projects/esptool/esptool/targets/esp32.py", line 173, in get_secure_boot_enabled
    efuses = self.read_reg(self.EFUSE_RD_ABS_DONE_REG)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 690, in read_reg
    val, data = self.command(
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration

Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

----------------------------------- Captured stdout setup ------------------------------------

**************************************************
------------------------------------ Captured stdout call ------------------------------------
Server started successfully.

Executing /home/nviditor/projects/esptool/.venv/bin/python -m esptool --chip esp32 --port rfc2217://localhost:52195?ign_set_control --baud 921600 write_flash 0x0 images/fifty_kb.bin...
esptool.py v4.5-dev
Serial port rfc2217://localhost:52195?ign_set_control
Connecting...
Device PID identification is only supported on COM and /dev/ serial ports.
.Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/nviditor/projects/esptool/esptool/__main__.py", line 11, in <module>
    esptool._main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 1032, in _main
    main()
  File "/home/nviditor/projects/esptool/esptool/__init__.py", line 832, in main
    operation_func(esp, args)
  File "/home/nviditor/projects/esptool/esptool/cmds.py", line 322, in write_flash
    if esp.get_secure_boot_enabled():
  File "/home/nviditor/projects/esptool/esptool/targets/esp32.py", line 173, in get_secure_boot_enabled
    efuses = self.read_reg(self.EFUSE_RD_ABS_DONE_REG)
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 690, in read_reg
    val, data = self.command(
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 376, in command
    p = self.read()
  File "/home/nviditor/projects/esptool/esptool/loader.py", line 308, in read
    return next(self._slip_reader)
StopIteration

Chip is ESP32-PICO-D4 (revision v1.0)
Features: WiFi, BT, Dual Core, 240MHz, Embedded Flash, VRef calibration in efuse, Coding Scheme None
Crystal is 40MHz
MAC: 4c:75:25:d4:dd:50
Uploading stub...
Running stub...
Stub running...
Changing baud rate to 921600
Changed.
Configuring flash size...

====================================== warnings summary ======================================
.venv/lib/python3.8/site-packages/_pytest/cacheprovider.py:433
  /home/nviditor/projects/esptool/.venv/lib/python3.8/site-packages/_pytest/cacheprovider.py:433: PytestCacheWarning: could not create cache path /.pytest_cache/v/cache/nodeids
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

.venv/lib/python3.8/site-packages/_pytest/cacheprovider.py:387
  /home/nviditor/projects/esptool/.venv/lib/python3.8/site-packages/_pytest/cacheprovider.py:387: PytestCacheWarning: could not create cache path /.pytest_cache/v/cache/lastfailed
    config.cache.set("cache/lastfailed", self.lastfailed)

.venv/lib/python3.8/site-packages/_pytest/stepwise.py:52
  /home/nviditor/projects/esptool/.venv/lib/python3.8/site-packages/_pytest/stepwise.py:52: PytestCacheWarning: could not create cache path /.pytest_cache/v/cache/stepwise
    session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================== short test summary info ===================================
FAILED test/test_esptool.py::TestFlashing::test_highspeed_flash - subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/pytho...
FAILED test/test_esptool.py::TestFlashing::test_compressed_nostub_flash - subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/pytho...
FAILED test/test_esptool.py::TestFlashing::test_partition_table_then_bootloader_nostub - subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/pytho...
FAILED test/test_esptool.py::TestKeepImageSettings::test_detect_size_changes_size - subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/pytho...
FAILED test/test_esptool.py::TestVirtualPort::test_highspeed_flash_virtual_port - subprocess.CalledProcessError: Command '['/home/nviditor/projects/esptool/.venv/bin/pytho...
========== 5 failed, 53 passed, 7 skipped, 3 warnings, 5 rerun in 946.22s (0:15:46) ==========
```

</details>