### PR TITLE
Add PKCS#8 identifier. (ESPTOOL-584)

### DIFF
--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -279,7 +279,11 @@ def _load_sbv2_pub_key(keydata):
 
 def _get_sbv2_pub_key(keyfile):
     key_data = keyfile.read()
-    if b"-BEGIN RSA PRIVATE KEY" in key_data or b"-BEGIN EC PRIVATE KEY" in key_data:
+    if (
+        b"-BEGIN RSA PRIVATE KEY" in key_data
+        or b"-BEGIN EC PRIVATE KEY" in key_data
+        or b"-BEGIN PRIVATE KEY" in key_data
+    ):
         return _load_sbv2_signing_key(key_data).public_key()
     elif b"-BEGIN PUBLIC KEY" in key_data:
         vk = _load_sbv2_pub_key(key_data)


### PR DESCRIPTION
# Description of change
Add extra condition to allow the serialization of PKCS#8 format. 

# This change fixes the following bug(s):
The [documentation](https://docs.espressif.com/projects/esp-idf/en/v4.4.3/esp32s3/security/secure-boot-v2.html#generating-secure-boot-signing-key) suggests to use the following command:

` openssl genrsa -out my_secure_boot_signing_key.pem 3072 `

This generates a PKCS#8 pem file starting with `-----BEGIN PRIVATE KEY-----` which is different to the expected `---BEGIN RSA PRIVATE KEY---`. 

Since `cryptography` [uses OpenSSL in the background](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/serialization/#cryptography.hazmat.primitives.serialization.load_pem_private_key) this change should not be dangerous. I have tested `espsecure.py` locally and it works as expected. 

> **[cryptography.exceptions.UnsupportedAlgorithm](https://cryptography.io/en/latest/exceptions/#cryptography.exceptions.UnsupportedAlgorithm)** – If the serialized key type is not supported by the OpenSSL version cryptography is using.

Before: 
```
espsecure.py verify_signature --version 2 --keyfile development_private_key_rsa_3072.pem fbebbae17cf48279e7dcbc3782f8581542b281ca.bin 
espsecure.py v4.5-dev

A fatal error occurred: Verification key does not appear to be an RSA Private or Public key in PEM format. Unsupported
```

After: 
```
espsecure.py verify_signature --version 2 --keyfile development_private_key_rsa_3072.pem fbebbae17cf48279e7dcbc3782f8581542b281ca.bin 
espsecure.py v4.5-dev
Signature block 0 is valid (RSA). 
Signature block 0 verification successful with /home/steven/Workspace/development_private_key_rsa_3072.pem (RSA).
Signature block 1 invalid. Skipping.
Signature block 2 invalid. Skipping.
```


# I have tested this change with the following hardware & software combinations:
**Operating system**: Arch Linux x86_64
**Kernel**: 6.1.1-arch1-1
**Chip name**: ESP32-S3 
**IDF version**: 4.4.3
**OpenSSL version**: OpenSSL 3.0.7 1 Nov 2022 (Library: OpenSSL 3.0.7 1 Nov 2022)

