### PR TITLE
refactor: Add python3 header to avoid python version confusion (ESPTOOL-589)

### DIFF
--- a/esp_rfc2217_server.py
+++ b/esp_rfc2217_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: 2009-2015 Chris Liechti
 # SPDX-FileContributor: 2020-2022 Espressif Systems (Shanghai) CO LTD

--- a/espefuse.py
+++ b/espefuse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2014-2022 Fredrik Ahlberg, Angus Gratton,
 # Espressif Systems (Shanghai) CO LTD, other contributors as noted.

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2016-2022 Espressif Systems (Shanghai) CO LTD
 #

--- a/espefuse/__main__.py
+++ b/espefuse/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2016-2022 Espressif Systems (Shanghai) CO LTD
 #

--- a/espefuse/efuse/base_fields.py
+++ b/espefuse/efuse/base_fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes the common eFuses structures for chips
 #

--- a/espefuse/efuse/base_operations.py
+++ b/espefuse/efuse/base_operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the common operations with eFuses for chips
 #

--- a/espefuse/efuse/emulate_efuse_controller_base.py
+++ b/espefuse/efuse/emulate_efuse_controller_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32 chip
 #

--- a/espefuse/efuse/esp32/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32 chip
 #

--- a/espefuse/efuse/esp32/fields.py
+++ b/espefuse/efuse/esp32/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32 chip
 #

--- a/espefuse/efuse/esp32/mem_definition.py
+++ b/espefuse/efuse/esp32/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32 chip
 #

--- a/espefuse/efuse/esp32/operations.py
+++ b/espefuse/efuse/esp32/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the operations with eFuses for ESP32 chip
 #

--- a/espefuse/efuse/esp32c2/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32c2/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-C2 chip
 #

--- a/espefuse/efuse/esp32c2/fields.py
+++ b/espefuse/efuse/esp32c2/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32-C2 chip
 #

--- a/espefuse/efuse/esp32c2/mem_definition.py
+++ b/espefuse/efuse/esp32c2/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32-C2 chip
 #

--- a/espefuse/efuse/esp32c2/operations.py
+++ b/espefuse/efuse/esp32c2/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the operations with eFuses for ESP32-C2 chip
 #

--- a/espefuse/efuse/esp32c3/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32c3/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-C3 chip
 #

--- a/espefuse/efuse/esp32c3/fields.py
+++ b/espefuse/efuse/esp32c3/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32-C3 chip
 #

--- a/espefuse/efuse/esp32c3/mem_definition.py
+++ b/espefuse/efuse/esp32c3/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32-C3 chip
 #

--- a/espefuse/efuse/esp32c3/operations.py
+++ b/espefuse/efuse/esp32c3/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the operations with eFuses for ESP32-C3 chip
 #

--- a/espefuse/efuse/esp32c6/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32c6/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-C6 chip
 #

--- a/espefuse/efuse/esp32c6/fields.py
+++ b/espefuse/efuse/esp32c6/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32-C6 chip
 #

--- a/espefuse/efuse/esp32c6/mem_definition.py
+++ b/espefuse/efuse/esp32c6/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32-C6 chip
 #

--- a/espefuse/efuse/esp32c6/operations.py
+++ b/espefuse/efuse/esp32c6/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the operations with eFuses for ESP32-C6 chip
 #

--- a/espefuse/efuse/esp32h2/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32h2/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32h2/fields.py
+++ b/espefuse/efuse/esp32h2/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32h2/mem_definition.py
+++ b/espefuse/efuse/esp32h2/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32h2/operations.py
+++ b/espefuse/efuse/esp32h2/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the operations with eFuses for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32h2beta1/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32h2beta1/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32h2beta1/fields.py
+++ b/espefuse/efuse/esp32h2beta1/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32h2beta1/mem_definition.py
+++ b/espefuse/efuse/esp32h2beta1/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32h2beta1/operations.py
+++ b/espefuse/efuse/esp32h2beta1/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the operations with eFuses for ESP32-H2 chip
 #

--- a/espefuse/efuse/esp32s2/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32s2/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-S2 chip
 #

--- a/espefuse/efuse/esp32s2/fields.py
+++ b/espefuse/efuse/esp32s2/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32S2 chip
 #

--- a/espefuse/efuse/esp32s2/mem_definition.py
+++ b/espefuse/efuse/esp32s2/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32 chip
 #

--- a/espefuse/efuse/esp32s2/operations.py
+++ b/espefuse/efuse/esp32s2/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file includes the operations with eFuses for ESP32S2 chip
 #

--- a/espefuse/efuse/esp32s3/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32s3/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-S3 chip
 #

--- a/espefuse/efuse/esp32s3/fields.py
+++ b/espefuse/efuse/esp32s3/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32-S3 chip
 #

--- a/espefuse/efuse/esp32s3/mem_definition.py
+++ b/espefuse/efuse/esp32s3/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32-S3 chip
 #

--- a/espefuse/efuse/esp32s3/operations.py
+++ b/espefuse/efuse/esp32s3/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This file includes the operations with eFuses for ESP32-S3 chip
 #
 # SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD

--- a/espefuse/efuse/esp32s3beta2/emulate_efuse_controller.py
+++ b/espefuse/efuse/esp32s3beta2/emulate_efuse_controller.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses controller for ESP32-S3(beta2) chip
 #

--- a/espefuse/efuse/esp32s3beta2/fields.py
+++ b/espefuse/efuse/esp32s3beta2/fields.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses for ESP32-S3 chip
 #

--- a/espefuse/efuse/esp32s3beta2/mem_definition.py
+++ b/espefuse/efuse/esp32s3beta2/mem_definition.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32-S3(beta2) chip
 #

--- a/espefuse/efuse/esp32s3beta2/operations.py
+++ b/espefuse/efuse/esp32s3beta2/operations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This file includes the operations with eFuses for ESP32-S3(beta2) chip
 #
 # SPDX-FileCopyrightText: 2020-2022 Espressif Systems (Shanghai) CO LTD

--- a/espefuse/efuse/mem_definition_base.py
+++ b/espefuse/efuse/mem_definition_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file describes eFuses fields and registers for ESP32 chip
 #

--- a/espefuse/efuse/util.py
+++ b/espefuse/efuse/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # This file consists of the common useful functions for eFuse
 #

--- a/espsecure.py
+++ b/espsecure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2014-2022 Fredrik Ahlberg, Angus Gratton,
 # Espressif Systems (Shanghai) CO LTD, other contributors as noted.

--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2016-2022 Espressif Systems (Shanghai) CO LTD
 #

--- a/espsecure/__main__.py
+++ b/espsecure/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2016-2022 Espressif Systems (Shanghai) CO LTD
 #

--- a/esptool.py
+++ b/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2014-2022 Fredrik Ahlberg, Angus Gratton,
 # Espressif Systems (Shanghai) CO LTD, other contributors as noted.

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2014-2022 Fredrik Ahlberg, Angus Gratton,
 # Espressif Systems (Shanghai) CO LTD, other contributors as noted.

--- a/esptool/__main__.py
+++ b/esptool/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2014-2022 Fredrik Ahlberg, Angus Gratton,
 # Espressif Systems (Shanghai) CO LTD, other contributors as noted.

--- a/flasher_stub/compare_stubs.py
+++ b/flasher_stub/compare_stubs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2014-2022 Fredrik Ahlberg, Angus Gratton,
 # Espressif Systems (Shanghai) CO LTD, other contributors as noted.

--- a/flasher_stub/esptool_test_stub.py
+++ b/flasher_stub/esptool_test_stub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # SPDX-FileCopyrightText: 2014-2022 Fredrik Ahlberg, Angus Gratton,
 # Espressif Systems (Shanghai) CO LTD, other contributors as noted.


### PR DESCRIPTION
# This change fixes the following bug(s):
./esptool.py fail on my python installation due to python version confusing. Add `/usr/bin/env python3` avoid this error.

# Description of change
Refactor done with bash one-liner :
```bash
grep -rl '/usr/bin/env python' . | xargs sed -i s@'/usr/bin/env python'@'/usr/bin/env python3'@g
```