### PR TITLE
espefuse: new argument for passing encryption key in command line instead of file path (ESPTOOL-621)

### DIFF
--- a/docs/en/espefuse/index.rst
+++ b/docs/en/espefuse/index.rst
@@ -56,6 +56,7 @@ Optional General Arguments Of Commands
 - ``--virt`` - For host tests. The tool will work in the virtual mode (without connecting to a chip).
 - ``--path-efuse-file`` - For host tests. Use it together with ``--virt`` option. The tool will work in the virtual mode (without connecting to a chip) and save eFuse memory to a given file. If the file does not exists the tool creates it. To reset written eFuses just delete the file. Usage: ``--path-efuse-file efuse_memory.bin``.
 - ``--do-not-confirm`` - Do not pause for confirmation before permanently writing eFuses. Use with caution. If this option is not used, a manual confirmation step is required, you need to enter the word ``BURN`` to continue burning.
+- ``--text-key`` - Data input for the ``keyfile`` argument is a 32 character string representing the encryption key itself instead of a string to a file path containing the key. When using this option, key content is also hidden in terminal output while burning fuses. Combining ``--text-key`` and ``--do-not-confirm`` options, esptool can then be invoked in an automated way by another software for prodcution flashing of encrypted firmware. In this case, neither the raw binary of firmware or the encryption key data are exposed outside the development environment.
 
 Virtual mode
 ^^^^^^^^^^^^

--- a/espefuse.py
+++ b/espefuse.py
@@ -32,3 +32,4 @@ import espefuse
 
 if __name__ == "__main__":
     espefuse._main()
+    

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -87,12 +87,12 @@ def get_esp(
     return esp
 
 
-def get_efuses(esp, skip_connect=False, debug_mode=False, do_not_confirm=False):
+def get_efuses(esp, skip_connect=False, debug_mode=False, do_not_confirm=False, text_key=False):
     for name in SUPPORTED_CHIPS:
         if SUPPORTED_CHIPS[name].chip_name == esp.CHIP_NAME:
             efuse = SUPPORTED_CHIPS[name].efuse_lib
             return (
-                efuse.EspEfuses(esp, skip_connect, debug_mode, do_not_confirm),
+                efuse.EspEfuses(esp, skip_connect, debug_mode, do_not_confirm, text_key),
                 efuse.operations,
             )
     else:
@@ -202,6 +202,11 @@ def main(custom_commandline=None):
         "Use with caution.",
         action="store_true",
     )
+    init_parser.add_argument(
+        "--text-key",
+        help="AES key input is text instead of file path.",
+        action="store_true",
+    )
 
     common_args, remaining_args = init_parser.parse_known_args(custom_commandline)
     debug_mode = common_args.debug or ("dump" in remaining_args)
@@ -229,7 +234,7 @@ def main(custom_commandline=None):
         )  # TODO: Require the --port argument in the next major release, ESPTOOL-490
 
     efuses, efuse_operations = get_efuses(
-        esp, just_print_help, debug_mode, common_args.do_not_confirm
+        esp, just_print_help, debug_mode, common_args.do_not_confirm, common_args.text_key
     )
 
     parser = argparse.ArgumentParser(parents=[init_parser])

--- a/espefuse/efuse/esp32/fields.py
+++ b/espefuse/efuse/esp32/fields.py
@@ -74,10 +74,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32 chip but got for '%s'."

--- a/espefuse/efuse/esp32/operations.py
+++ b/espefuse/efuse/esp32/operations.py
@@ -225,12 +225,18 @@ def burn_key(esp, efuses, args):
         if efuse is None:
             raise esptool.FatalError("Unknown block name - %s" % (block_name))
         num_bytes = efuse.bit_len // 8
-        data = datafile.read()
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        else:
+            data = datafile.read()
         revers_msg = None
         if block_name in ("flash_encryption", "secure_boot_v1"):
             revers_msg = "\tReversing the byte order"
             data = data[::-1]
-        print(" - %s -> [%s]" % (efuse.name, util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print(" - %s -> [%s]" % (efuse.name, util.hexify(data, " ")))
+        else:
+            print(" - %s -> [%s]" % (efuse.name, "HIDDEN DATA"))
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:

--- a/espefuse/efuse/esp32c2/fields.py
+++ b/espefuse/efuse/esp32c2/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-C2":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-C2 chip but got for '%s'."

--- a/espefuse/efuse/esp32c2/operations.py
+++ b/espefuse/efuse/esp32c2/operations.py
@@ -211,7 +211,10 @@ def burn_key(esp, efuses, args, digest=None):
 
     print("Burn keys to blocks:")
     for datafile, keypurpose in zip(datafile_list, keypurpose_list):
-        data = datafile if isinstance(datafile, bytes) else datafile.read()
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        else:
+            data = datafile if isinstance(datafile, bytes) else datafile.read()
 
         if keypurpose == "XTS_AES_128_KEY_DERIVED_FROM_128_EFUSE_BITS":
             efuse = efuses["BLOCK_KEY0_LOW_128"]
@@ -239,7 +242,10 @@ def burn_key(esp, efuses, args, digest=None):
         if keypurpose.startswith("XTS_AES_"):
             revers_msg = "\tReversing byte order for AES-XTS hardware peripheral"
             data = data[::-1]
-        print("-> [%s]" % (util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print("-> [%s]" % (util.hexify(data, " ")))
+        else:
+            print("-> [%s]" % "HIDDEN CONTENT")
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:

--- a/espefuse/efuse/esp32c3/fields.py
+++ b/espefuse/efuse/esp32c3/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-C3":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-C3 chip but got for '%s'."

--- a/espefuse/efuse/esp32c6/fields.py
+++ b/espefuse/efuse/esp32c6/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-C6":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-C6 chip but got for '%s'."

--- a/espefuse/efuse/esp32c6/operations.py
+++ b/espefuse/efuse/esp32c6/operations.py
@@ -266,7 +266,9 @@ def burn_key(esp, efuses, args, digest=None):
         block_num = efuses.get_index_block_by_name(block_name)
         block = efuses.blocks[block_num]
 
-        if digest is None:
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        elif digest is None:
             data = datafile.read()
         else:
             data = datafile
@@ -276,7 +278,10 @@ def burn_key(esp, efuses, args, digest=None):
         if efuses[block.key_purpose_name].need_reverse(keypurpose):
             revers_msg = "\tReversing byte order for AES-XTS hardware peripheral"
             data = data[::-1]
-        print("-> [%s]" % (util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print("-> [%s]" % (util.hexify(data, " ")))
+        else:
+            print("-> [%s]" % "HIDDEN CONTENT")
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:

--- a/espefuse/efuse/esp32h2/fields.py
+++ b/espefuse/efuse/esp32h2/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-H2":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-H2 chip but got for '%s'."

--- a/espefuse/efuse/esp32h2/operations.py
+++ b/espefuse/efuse/esp32h2/operations.py
@@ -266,7 +266,9 @@ def burn_key(esp, efuses, args, digest=None):
         block_num = efuses.get_index_block_by_name(block_name)
         block = efuses.blocks[block_num]
 
-        if digest is None:
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        elif digest is None:
             data = datafile.read()
         else:
             data = datafile
@@ -276,7 +278,10 @@ def burn_key(esp, efuses, args, digest=None):
         if efuses[block.key_purpose_name].need_reverse(keypurpose):
             revers_msg = "\tReversing byte order for AES-XTS hardware peripheral"
             data = data[::-1]
-        print("-> [%s]" % (util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print("-> [%s]" % (util.hexify(data, " ")))
+        else:
+            print("-> [%s]" % "HIDDEN CONTENT")
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:

--- a/espefuse/efuse/esp32h2beta1/fields.py
+++ b/espefuse/efuse/esp32h2beta1/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-H2(beta1)":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-H2(beta1) chip but got for '%s'."

--- a/espefuse/efuse/esp32h2beta1/operations.py
+++ b/espefuse/efuse/esp32h2beta1/operations.py
@@ -266,7 +266,9 @@ def burn_key(esp, efuses, args, digest=None):
         block_num = efuses.get_index_block_by_name(block_name)
         block = efuses.blocks[block_num]
 
-        if digest is None:
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        elif digest is None:
             data = datafile.read()
         else:
             data = datafile
@@ -276,7 +278,10 @@ def burn_key(esp, efuses, args, digest=None):
         if efuses[block.key_purpose_name].need_reverse(keypurpose):
             revers_msg = "\tReversing byte order for AES-XTS hardware peripheral"
             data = data[::-1]
-        print("-> [%s]" % (util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print("-> [%s]" % (util.hexify(data, " ")))
+        else:
+            print("-> [%s]" % "HIDDEN CONTENT")
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:

--- a/espefuse/efuse/esp32s2/fields.py
+++ b/espefuse/efuse/esp32s2/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-S2":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-S2 chip but got for '%s'."

--- a/espefuse/efuse/esp32s2/operations.py
+++ b/espefuse/efuse/esp32s2/operations.py
@@ -375,7 +375,9 @@ def burn_key(esp, efuses, args, digest=None):
         block_num = efuses.get_index_block_by_name(block_name)
         block = efuses.blocks[block_num]
 
-        if digest is None:
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        elif digest is None:
             data = datafile.read()
         else:
             data = datafile
@@ -385,7 +387,10 @@ def burn_key(esp, efuses, args, digest=None):
         if efuses[block.key_purpose_name].need_reverse(keypurpose):
             revers_msg = "\tReversing byte order for AES-XTS hardware peripheral"
             data = data[::-1]
-        print("-> [%s]" % (util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print("-> [%s]" % (util.hexify(data, " ")))
+        else:
+            print("-> [%s]" % "HIDDEN CONTENT")
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:

--- a/espefuse/efuse/esp32s3/fields.py
+++ b/espefuse/efuse/esp32s3/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-S3":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-S3 chip but got for '%s'."

--- a/espefuse/efuse/esp32s3/operations.py
+++ b/espefuse/efuse/esp32s3/operations.py
@@ -374,7 +374,9 @@ def burn_key(esp, efuses, args, digest=None):
         block_num = efuses.get_index_block_by_name(block_name)
         block = efuses.blocks[block_num]
 
-        if digest is None:
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        elif digest is None:
             data = datafile.read()
         else:
             data = datafile
@@ -384,7 +386,10 @@ def burn_key(esp, efuses, args, digest=None):
         if efuses[block.key_purpose_name].need_reverse(keypurpose):
             revers_msg = "\tReversing byte order for AES-XTS hardware peripheral"
             data = data[::-1]
-        print("-> [%s]" % (util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print("-> [%s]" % (util.hexify(data, " ")))
+        else:
+            print("-> [%s]" % "HIDDEN CONTENT")
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:

--- a/espefuse/efuse/esp32s3beta2/fields.py
+++ b/espefuse/efuse/esp32s3beta2/fields.py
@@ -63,10 +63,11 @@ class EspEfuses(base_fields.EspEfusesBase):
     debug = False
     do_not_confirm = False
 
-    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False):
+    def __init__(self, esp, skip_connect=False, debug=False, do_not_confirm=False, text_key=False):
         self._esp = esp
         self.debug = debug
         self.do_not_confirm = do_not_confirm
+        self.text_key = text_key
         if esp.CHIP_NAME != "ESP32-S3(beta2)":
             raise esptool.FatalError(
                 "Expected the 'esp' param for ESP32-S3(beta2) chip but got for '%s'."

--- a/espefuse/efuse/esp32s3beta2/operations.py
+++ b/espefuse/efuse/esp32s3beta2/operations.py
@@ -374,7 +374,9 @@ def burn_key(esp, efuses, args, digest=None):
         block_num = efuses.get_index_block_by_name(block_name)
         block = efuses.blocks[block_num]
 
-        if digest is None:
+        if efuses.text_key is True:
+            data = bytearray.fromhex(datafile)
+        elif digest is None:
             data = datafile.read()
         else:
             data = datafile
@@ -384,7 +386,10 @@ def burn_key(esp, efuses, args, digest=None):
         if efuses[block.key_purpose_name].need_reverse(keypurpose):
             revers_msg = "\tReversing byte order for AES-XTS hardware peripheral"
             data = data[::-1]
-        print("-> [%s]" % (util.hexify(data, " ")))
+        if efuses.text_key is False:
+            print("-> [%s]" % (util.hexify(data, " ")))
+        else:
+            print("-> [%s]" % "HIDDEN CONTENT")
         if revers_msg:
             print(revers_msg)
         if len(data) != num_bytes:


### PR DESCRIPTION
# Description of change
Added a new command parameter in espefuse for passing the encryption key as argument instead of using a file on disk. The parametere is named ``--text-key``. The purpose of this change is to provide firmware already encrypted to the production environment. The encryption key is passed as argument to esptool by a C++ software. To burn the fuses and flash the firmware, a single button needs to be pressed, while the key is not stored on disk, not shown on terminal and firmware binary files are already encrypted.

# I have tested this change with the following hardware & software combinations:
``python esptool\espefuse.py --chip esp32c3 --port COM7 burn_key BLOCK_KEY0 0000111122223333444455556666777788889999aaaabbbbccccddddeeeeffff XTS_AES_128_KEY --text-key --do-not-confirm``

As I only have an ESP32C3, this mod was just tested on it. I put the equivalent code for other ESP models, but they need to be tested though.