### PR TITLE
flasher_stub: pass -mabi=ilp32, add EXTRA_CFLAGS, to allow building with a stock compiler (ESPTOOL-643)

### DIFF
--- a/flasher_stub/Makefile
+++ b/flasher_stub/Makefile
@@ -83,7 +83,7 @@ CFLAGS = -std=c99 -Wall -Werror -Os \
          -mtext-section-literals -mlongcalls -nostdlib -fno-builtin -flto \
          -Wl,-static -g -ffunction-sections -Wl,--gc-sections -Iinclude -Lld
 CFLAGS_ESPRISCV32 = -std=c99 -Wall -Werror -Os \
-		 -march=rv32imc -msmall-data-limit=0 \
+		 -march=rv32imc -mabi=ilp32 -msmall-data-limit=0 \
          -nostdlib -fno-builtin -flto \
          -Wl,-static -g -ffunction-sections -Wl,--gc-sections -Iinclude -Lld
 LDLIBS = -lgcc

--- a/flasher_stub/Makefile
+++ b/flasher_stub/Makefile
@@ -38,6 +38,10 @@ CROSS_32S2 ?= xtensa-esp32s2-elf-
 CROSS_32S3 ?= xtensa-esp32s3-elf-
 CROSS_ESPRISCV32 ?= riscv32-esp-elf-
 
+# extra CFLAGS to be passed on the compiler, in addition to the stock ones
+EXTRA_CFLAGS ?=
+EXTRA_CFLAGS_ESPRISCV32 ?=
+
 # Python command to invoke wrap_stub.py
 WRAP_STUB ?= ./wrap_stub.py
 
@@ -81,11 +85,13 @@ $(BUILD_DIR):
 
 CFLAGS = -std=c99 -Wall -Werror -Os \
          -mtext-section-literals -mlongcalls -nostdlib -fno-builtin -flto \
-         -Wl,-static -g -ffunction-sections -Wl,--gc-sections -Iinclude -Lld
+         -Wl,-static -g -ffunction-sections -Wl,--gc-sections -Iinclude -Lld \
+         $(EXTRA_CFLAGS)
 CFLAGS_ESPRISCV32 = -std=c99 -Wall -Werror -Os \
 		 -march=rv32imc -mabi=ilp32 -msmall-data-limit=0 \
          -nostdlib -fno-builtin -flto \
-         -Wl,-static -g -ffunction-sections -Wl,--gc-sections -Iinclude -Lld
+         -Wl,-static -g -ffunction-sections -Wl,--gc-sections -Iinclude -Lld \
+         $(EXTRA_CFLAGS_ESPRISCV32)
 LDLIBS = -lgcc
 
 $(STUB_ELF_8266): $(SRCS) $(SRCS_8266) $(BUILD_DIR) ld/stub_8266.ld | Makefile


### PR DESCRIPTION
## Description of the change

I'm trying to resume work that I started a few years ago (see #499, #500, #501, [Debian bug #948096](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=948096)) to try to have Debian ship the esptool flasher stubs.

The TL;DR is that packages in Debian need to build from source and cannot ship binary blobs, and that includes both the stub binaries, as well as precompiled toolchains. Therefore the current Debian maintainer has opted into removing the stubs entirely. (The package is also a bit stagnated, currently at v2.8, and I'm trying to fix that).

For the RISC-V chips, there is no riscv32-esp-elf-gcc compiler in Debian (obviously :), but riscv64-unknown-elf-gcc (`riscv64-unknown-elf-gcc (12.1.0-7+11) 12.1.0`) exists, and picolibc supports RISC-V as well. What is required on a recent Debian system is:
```
apt install gcc-riscv64-unknown-elf picolibc-riscv64-unknown-elf
```
...plus the two commits in this PR, and then:
```
CROSS_ESPRISCV32=riscv64-unknown-elf- EXTRA_CFLAGS_ESPRISCV32=-specs=picolibc.specs make
```

After this, the resulting stub for a ESP32-C3 that I have in my disposal seemed to work fine for me. I don't have any other RISCV hardware to test this with.

Yes, I realize this will be entirely unsupported by Espressif. The two changes here are miniscule and **no-ops** for the Espressif toolchain -- the in-tree precompiled blobs remain unchanged.

## Side note

The ESP8266 stub also builds and works on another test board that I have. No modifications are necessary. All that's needed is to:
```
apt install gcc-xtensa-lx106 picolibc-xtensa-lx106-elf
```
For the record, these are `xtensa-lx106-elf-gcc (12.2.0-9+12) 12.2.0` and picolibc 1.8.

Sadly, there is no compiler for the ESP32/ESP32-S2/ESP32-S3 in Debian, nor there is support for them in picolibc. Currently I have local patches to remove `$(STUB_ELF_32) $(STUB_ELF_32S2) $(STUB_ELF_32S3_BETA_2) $(STUB_ELF_32S3)` from `all` and `embed`. It'd be nice to have some generalized way to build for specific chips.