### PR TITLE
fix(ESP32-C6): Fix get_pkg_version and get_{major,minor}_chip_version (ESPTOOL-657)

### DIFF
--- a/esptool/targets/esp32c6.py
+++ b/esptool/targets/esp32c6.py
@@ -98,18 +98,15 @@ class ESP32C6ROM(ESP32C3ROM):
 
     def get_pkg_version(self):
         num_word = 3
-        return (self.read_reg(self.EFUSE_BLOCK1_ADDR + (4 * num_word)) >> 21) & 0x07
+        return (self.read_reg(self.EFUSE_BLOCK1_ADDR + (4 * num_word)) >> 29) & 0x07
 
     def get_minor_chip_version(self):
-        hi_num_word = 5
-        hi = (self.read_reg(self.EFUSE_BLOCK1_ADDR + (4 * hi_num_word)) >> 23) & 0x01
-        low_num_word = 3
-        low = (self.read_reg(self.EFUSE_BLOCK1_ADDR + (4 * low_num_word)) >> 18) & 0x07
-        return (hi << 3) + low
+        num_word = 3
+        return (self.read_reg(self.EFUSE_BLOCK1_ADDR + (4 * num_word)) >> 18) & 0x0F
 
     def get_major_chip_version(self):
-        num_word = 5
-        return (self.read_reg(self.EFUSE_BLOCK1_ADDR + (4 * num_word)) >> 24) & 0x03
+        num_word = 3
+        return (self.read_reg(self.EFUSE_BLOCK1_ADDR + (4 * num_word)) >> 22) & 0x03
 
     def get_chip_description(self):
         chip_name = {


### PR DESCRIPTION
# Description of change

The current implementation appears to be reading the package version and chip version from the wrong efuse bits. Based on [`efuse_reg.h`](https://github.com/espressif/esp-idf/blob/ab63aaa4a24a05904da2862d627f3987ecbeafd0/components/soc/esp32c6/include/soc/efuse_reg.h#L709) and [`esp_efuse_table.csv`](https://github.com/espressif/esp-idf/blob/ab63aaa4a24a05904da2862d627f3987ecbeafd0/components/efuse/esp32c6/esp_efuse_table.csv#L139), this pull request addresses the issue.

# This change fixes the following bug(s):

https://github.com/espressif/esptool/issues/866

# I have tested this change with the following hardware & software combinations:

* macOS 13.2.1 (22D68)
* Python 3.11.2
* ESP32-C6-DevKitM-1 V1.0