### PR TITLE
Image info stuff (ESPTOOL-675)

### DIFF
--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -737,7 +737,10 @@ def image_info(args):
             title = "{} extended image header".format(args.chip.upper())
             print(title)
             print("=" * len(title))
-            print("WP pin: {:#02x}".format(image.wp_pin))
+            print(
+                f"WP pin: {image.wp_pin:#02x}",
+                *["(disabled)"] if image.wp_pin == image.WP_PIN_DISABLED else [],
+            )
             print(
                 "Flash pins drive settings: "
                 "clk_drv: {:#02x}, q_drv: {:#02x}, d_drv: {:#02x}, "

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -753,7 +753,15 @@ def image_info(args):
                     image.wp_drv,
                 )
             )
-            print("Chip ID: {}".format(image.chip_id))
+            try:
+                chip = next(
+                    chip
+                    for chip in CHIP_DEFS.values()
+                    if getattr(chip, "IMAGE_CHIP_ID", None) == image.chip_id
+                )
+                print(f"Chip ID: {image.chip_id} ({chip.CHIP_NAME})")
+            except StopIteration:
+                print(f"Chip ID: {image.chip_id} (Unknown ID)")
             print(
                 "Minimal chip revision: "
                 f"v{image.min_rev_full // 100}.{image.min_rev_full % 100}, "

--- a/test/test_image_info.py
+++ b/test/test_image_info.py
@@ -87,7 +87,7 @@ class TestImageInfo:
 
         # Extended header
         assert "WP pin: 0xee (disabled)" in out, "Wrong WP pin"
-        assert "Chip ID: 5" in out, "Wrong chip ID"
+        assert "Chip ID: 5 (ESP32-C3)" in out, "Wrong chip ID"
         assert (
             "clk_drv: 0x0, q_drv: 0x0, d_drv: 0x0, "
             "cs0_drv: 0x0, hd_drv: 0x0, wp_drv: 0x0" in out

--- a/test/test_image_info.py
+++ b/test/test_image_info.py
@@ -86,7 +86,7 @@ class TestImageInfo:
         assert "Flash mode: DIO" in out, "Wrong flash mode"
 
         # Extended header
-        assert "WP pin: 0xee" in out, "Wrong WP pin"
+        assert "WP pin: 0xee (disabled)" in out, "Wrong WP pin"
         assert "Chip ID: 5" in out, "Wrong chip ID"
         assert (
             "clk_drv: 0x0, q_drv: 0x0, d_drv: 0x0, "


### PR DESCRIPTION
# Description of change
Add some additional decoding for the image_info command.

# I have tested this change with the following hardware & software combinations:

Linux.  image_info doesn't interact with boards.