### PR TITLE
Fix USB-JTAG-Serial PID detection error (ESPTOOL-682)

### DIFF
--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -494,12 +494,14 @@ class ESPLoader(object):
         if active_port.startswith("/dev/") and os.path.islink(active_port):
             active_port = os.path.realpath(active_port)
 
+        active_ports = [active_port]
+
         # The "cu" (call-up) device has to be used for outgoing communication on MacOS
         if sys.platform == "darwin" and "tty" in active_port:
-            active_port = [active_port, active_port.replace("tty", "cu")]
+            active_ports.append(active_port.replace("tty", "cu"))
         ports = list_ports.comports()
         for p in ports:
-            if p.device in active_port:
+            if p.device in active_ports:
                 return p.pid
         print(
             "\nFailed to get PID of a device on {}, "


### PR DESCRIPTION
# Description of change

Fixes the detection of USB-JTAG-Serial on ports COM10 and greater due to incorrect PID retrieval.

Commit https://github.com/espressif/esptool/commit/00f4bc967c94b25e3190ebc007a0bf132ae42f02 introduced a bug which changed port names to be matched by `in` when not running on darwin, this means `_get_pid` can instead return the PID for `COM1` instead of `COM10` - `COM19`.
