### PR TITLE
fix: inconsistent usage of dirs separator (ESPTOOL-689)

### DIFF
--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -97,13 +97,13 @@ DEFAULT_CONNECT_ATTEMPTS = cfg.getint("connect_attempts", 7)
 # Number of times to try writing a data block
 WRITE_BLOCK_ATTEMPTS = cfg.getint("write_block_attempts", 3)
 
-STUBS_DIR = os.path.join(os.path.dirname(__file__), "./targets/stub_flasher/")
+STUBS_DIR = os.path.join(os.path.dirname(__file__), "targets", "stub_flasher")
 
 
 def get_stub_json_path(chip_name):
     chip_name = strip_chip_name(chip_name)
     chip_name = chip_name.replace("esp", "")
-    return STUBS_DIR + "stub_flasher_" + chip_name + ".json"
+    return os.path.join(STUBS_DIR, f"stub_flasher_{chip_name}.json")
 
 
 def timeout_per_mb(seconds_per_mb, size_bytes):

--- a/flasher_stub/wrap_stub.py
+++ b/flasher_stub/wrap_stub.py
@@ -17,7 +17,7 @@ sys.path.append("..")
 import esptool  # noqa: E402
 
 THIS_DIR = os.path.dirname(__file__)
-BUILD_DIR = os.path.join(THIS_DIR, "./build/")
+BUILD_DIR = os.path.join(THIS_DIR, "build")
 
 
 def wrap_stub(elf_file):
@@ -66,7 +66,7 @@ def write_json_files(stubs_dict):
             return json.JSONEncoder.default(self, obj)
 
     for filename, stub_data in stubs_dict.items():
-        with open(BUILD_DIR + filename, "w") as outfile:
+        with open(os.path.join(BUILD_DIR, filename), "w") as outfile:
             json.dump(stub_data, outfile, cls=BytesEncoder, indent=4)
 
 

--- a/test/test_espefuse.py
+++ b/test/test_espefuse.py
@@ -36,9 +36,9 @@ from bitstring import BitStream
 from conftest import arg_chip, arg_port, arg_reset_port, need_to_install_package_err
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
-IMAGES_DIR = os.path.join(TEST_DIR, "images/efuse/")
-S_IMAGES_DIR = os.path.join(TEST_DIR, "secure_images/")
-EFUSE_S_DIR = os.path.join(TEST_DIR, "efuse_scripts/")
+IMAGES_DIR = os.path.join(TEST_DIR, "images", "efuse")
+S_IMAGES_DIR = os.path.join(TEST_DIR, "secure_images")
+EFUSE_S_DIR = os.path.join(TEST_DIR, "efuse_scripts")
 
 import pytest
 

--- a/test/test_image_info.py
+++ b/test/test_image_info.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     need_to_install_package_err()
 
-IMAGES_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "images/")
+IMAGES_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "images")
 
 ESP8266_BIN = "not_4_byte_aligned.bin"
 
@@ -40,7 +40,7 @@ class TestImageInfo:
         ]
         if version is not None:
             cmd += ["--version", str(version)]
-        cmd += ["".join([IMAGES_DIR, file])]
+        cmd += ["".join([IMAGES_DIR, os.sep, file])]
         print("\nExecuting {}".format(" ".join(cmd)))
 
         try:


### PR DESCRIPTION
# Description of change
Fixes the wrong usage of os specific directory separators

# I have tested this change with the following hardware & software combinations:

OS: macOS, Windows
development board: ESP8266
