### PR TITLE
espsecure: read_hsm_config now can prompt for HSM PIN (ESPTOOL-716)

### DIFF
--- a/docs/en/espsecure/index.rst
+++ b/docs/en/espsecure/index.rst
@@ -50,6 +50,9 @@ HSM config file
 An HSM config file is required with the fields (``pkcs11_lib``, ``credentials``, ``slot``, ``label``, ``label_pubkey``)
 populated corresponding to the HSM used.
 
+To avoid storing the PIN in plaintext, you could simply remove the ``credentials`` option from the config file,
+and during signing using the HSM, you will be prompted to type in the HSM Pin.
+
 Below is a sample HSM config file (``hsm_config.ini``) for using `SoftHSMv2 <https://github.com/opendnssec/SoftHSMv2>`_ as an external HSM: ::
 
     # hsm_config.ini

--- a/espsecure/esp_hsm_sign/__init__.py
+++ b/espsecure/esp_hsm_sign/__init__.py
@@ -6,6 +6,7 @@ import binascii
 import configparser
 import os
 import sys
+from getpass import getpass
 
 try:
     import pkcs11
@@ -31,10 +32,16 @@ def read_hsm_config(configfile):
     if not config.has_section(section):
         raise configparser.NoSectionError(section)
 
-    section_options = ["pkcs11_lib", "credentials", "slot", "label"]
+    section_options = ["pkcs11_lib", "slot", "label"]
     for option in section_options:
         if not config.has_option(section, option):
             raise configparser.NoOptionError(option, section)
+
+    # If the config file does not contain the "credentials" option,
+    # prompt the user for the HSM PIN
+    if not config.has_option(section, "credentials"):
+        hsm_pin = getpass("Please enter the PIN of your HSM:\n")
+        config.set(section, "credentials", hsm_pin)
 
     return config[section]
 


### PR DESCRIPTION
# Description of change

If the config file contains `credentials = prompt` during image signing process, the user will be prompted to type in the HSM PIN. This avoids the need to have the HSM PIN written as plaintext into a config file, which is not a secure practice.

# I have tested this change with the following hardware & software combinations:
espsecure using NitroKey HSM2 HW on Linux Ubuntu 22.04

