### PR TITLE
feat: print exceptions to stderr (ESPTOOL-731)

### DIFF
--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -294,7 +294,7 @@ def _main():
     try:
         main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e)
+        print("\nA fatal error occurred: %s" % e, file=sys.stderr)
         sys.exit(2)
 
 

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -20,7 +20,7 @@ import espefuse.efuse.esp32s3 as esp32s3_efuse
 import espefuse.efuse.esp32s3beta2 as esp32s3beta2_efuse
 
 import esptool
-from esptool.loader import REDIRECT_ERROR
+from esptool.loader import REDIRECT_ERRORS
 
 DefChip = namedtuple("DefChip", ["chip_name", "efuse_lib", "chip_class"])
 
@@ -216,7 +216,7 @@ def main(custom_commandline=None, esp=None):
         "--redirect-errors",
         help="Redirect errors to stderr instead of stdout",
         action="store_true",
-        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
+        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
     )
 
     common_args, remaining_args = init_parser.parse_known_args(custom_commandline)

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -304,7 +304,7 @@ def _main():
     try:
         main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e, file=sys.stderr)
+        print("\nA fatal error occurred: %s" % e, file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
         sys.exit(2)
 
 

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -212,13 +212,6 @@ def main(custom_commandline=None, esp=None):
         action="store_true",
     )
 
-    init_parser.add_argument(
-        "--redirect-errors",
-        help="Redirect errors to stderr instead of stdout",
-        action="store_true",
-        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
-    )
-
     common_args, remaining_args = init_parser.parse_known_args(custom_commandline)
     debug_mode = common_args.debug or ("dump" in remaining_args)
     just_print_help = [
@@ -270,8 +263,6 @@ def main(custom_commandline=None, esp=None):
     try:
         for rem_args in grouped_remaining_args:
             args, unused_args = parser.parse_known_args(rem_args, namespace=common_args)
-            globals()["redirect_errors"] = args.redirect_errors
-
             if args.operation is None:
                 parser.print_help()
                 parser.exit(1)
@@ -306,7 +297,7 @@ def _main():
     except esptool.FatalError as e:
         print(
             "\nA fatal error occurred: %s" % e,
-            file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+            file=sys.stderr if REDIRECT_ERRORS else sys.stdout,
         )
         sys.exit(2)
 

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -20,6 +20,7 @@ import espefuse.efuse.esp32s3 as esp32s3_efuse
 import espefuse.efuse.esp32s3beta2 as esp32s3beta2_efuse
 
 import esptool
+from esptool.loader import REDIRECT_ERROR
 
 DefChip = namedtuple("DefChip", ["chip_name", "efuse_lib", "chip_class"])
 
@@ -211,6 +212,13 @@ def main(custom_commandline=None, esp=None):
         action="store_true",
     )
 
+    init_parser.add_argument(
+        "--redirect-errors",
+        help="Redirect errors to stderr instead of stdout",
+        action="store_true",
+        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
+    )
+
     common_args, remaining_args = init_parser.parse_known_args(custom_commandline)
     debug_mode = common_args.debug or ("dump" in remaining_args)
     just_print_help = [
@@ -262,6 +270,8 @@ def main(custom_commandline=None, esp=None):
     try:
         for rem_args in grouped_remaining_args:
             args, unused_args = parser.parse_known_args(rem_args, namespace=common_args)
+            globals()["redirect_errors"] = args.redirect_errors
+
             if args.operation is None:
                 parser.print_help()
                 parser.exit(1)

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -304,7 +304,10 @@ def _main():
     try:
         main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e, file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
+        print(
+            "\nA fatal error occurred: %s" % e,
+            file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+        )
         sys.exit(2)
 
 

--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -23,7 +23,7 @@ from cryptography.utils import int_to_bytes
 import ecdsa
 
 import esptool
-from esptool.loader import REDIRECT_ERROR
+from esptool.loader import REDIRECT_ERRORS
 
 SIG_BLOCK_MAGIC = 0xE7
 
@@ -1433,7 +1433,7 @@ def main(custom_commandline=None):
         "--redirect-errors",
         help="Redirect errors to stderr instead of stdout",
         action="store_true",
-        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
+        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
     )
 
     subparsers = parser.add_subparsers(

--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -23,6 +23,7 @@ from cryptography.utils import int_to_bytes
 import ecdsa
 
 import esptool
+from esptool.loader import REDIRECT_ERROR
 
 SIG_BLOCK_MAGIC = 0xE7
 
@@ -1428,6 +1429,13 @@ def main(custom_commandline=None):
         prog="espsecure",
     )
 
+    parser.add_argument(
+        "--redirect-errors",
+        help="Redirect errors to stderr instead of stdout",
+        action="store_true",
+        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
+    )
+
     subparsers = parser.add_subparsers(
         dest="operation", help="Run espsecure.py {command} -h for additional help"
     )
@@ -1790,6 +1798,7 @@ def main(custom_commandline=None):
     )
 
     args = parser.parse_args(custom_commandline)
+    globals()["redirect_errors"] = args.redirect_errors
     print("espsecure.py v%s" % esptool.__version__)
     if args.operation is None:
         parser.print_help()

--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -1810,7 +1810,7 @@ def _main():
     try:
         main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e)
+        print("\nA fatal error occurred: %s" % e, file=sys.stderr)
         sys.exit(2)
     except ValueError as e:
         try:
@@ -1819,6 +1819,7 @@ def _main():
                     "Note: This error originates from the cryptography module. "
                     "It is likely not a problem with espsecure, "
                     "please make sure you are using a compatible OpenSSL backend."
+                    , file=sys.stderr
                 )
         finally:
             raise

--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -1819,7 +1819,7 @@ def _main():
     try:
         main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e, file=sys.stderr)
+        print("\nA fatal error occurred: %s" % e, file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
         sys.exit(2)
     except ValueError as e:
         try:
@@ -1828,7 +1828,7 @@ def _main():
                     "Note: This error originates from the cryptography module. "
                     "It is likely not a problem with espsecure, "
                     "please make sure you are using a compatible OpenSSL backend."
-                    , file=sys.stderr
+                    , file=sys.stderr if globals()["redirect_errors"] else sys.stdout
                 )
         finally:
             raise

--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -1429,13 +1429,6 @@ def main(custom_commandline=None):
         prog="espsecure",
     )
 
-    parser.add_argument(
-        "--redirect-errors",
-        help="Redirect errors to stderr instead of stdout",
-        action="store_true",
-        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
-    )
-
     subparsers = parser.add_subparsers(
         dest="operation", help="Run espsecure.py {command} -h for additional help"
     )
@@ -1798,7 +1791,6 @@ def main(custom_commandline=None):
     )
 
     args = parser.parse_args(custom_commandline)
-    globals()["redirect_errors"] = args.redirect_errors
     print("espsecure.py v%s" % esptool.__version__)
     if args.operation is None:
         parser.print_help()
@@ -1821,7 +1813,7 @@ def _main():
     except esptool.FatalError as e:
         print(
             "\nA fatal error occurred: %s" % e,
-            file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+            file=sys.stderr if REDIRECT_ERRORS else sys.stdout,
         )
         sys.exit(2)
     except ValueError as e:
@@ -1831,7 +1823,7 @@ def _main():
                     "Note: This error originates from the cryptography module. "
                     "It is likely not a problem with espsecure, "
                     "please make sure you are using a compatible OpenSSL backend.",
-                    file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+                    file=sys.stderr if REDIRECT_ERRORS else sys.stdout,
                 )
         finally:
             raise

--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -1819,7 +1819,10 @@ def _main():
     try:
         main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e, file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
+        print(
+            "\nA fatal error occurred: %s" % e,
+            file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+        )
         sys.exit(2)
     except ValueError as e:
         try:
@@ -1827,8 +1830,8 @@ def _main():
                 print(
                     "Note: This error originates from the cryptography module. "
                     "It is likely not a problem with espsecure, "
-                    "please make sure you are using a compatible OpenSSL backend."
-                    , file=sys.stderr if globals()["redirect_errors"] else sys.stdout
+                    "please make sure you are using a compatible OpenSSL backend.",
+                    file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
                 )
         finally:
             raise

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -1080,25 +1080,27 @@ def _main():
     try:
         main()
     except FatalError as e:
-        print(f"\nA fatal error occurred: {e}", file=sys.stderr)
+        print(f"\nA fatal error occurred: {e}", file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
         sys.exit(2)
     except serial.serialutil.SerialException as e:
-        print(f"\nA serial exception error occurred: {e}", file=sys.stderr)
+        file = sys.stderr if globals()["redirect_errors"] else sys.stdout
+        print(f"\nA serial exception error occurred: {e}", file=file)
         print(
             "Note: This error originates from pySerial. "
             "It is likely not a problem with esptool, "
             "but with the hardware connection or drivers."
-            , file=sys.stderr
+            , file=file
         )
         print(
             "For troubleshooting steps visit: "
             "https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html"
-            , file=sys.stderr
+            , file=file
         )
         sys.exit(1)
     except StopIteration:
-        print(traceback.format_exc(), file=sys.stderr)
-        print("A fatal error occurred: The chip stopped responding.", file=sys.stderr)
+        file = sys.stderr if globals()["redirect_errors"] else sys.stdout
+        print(traceback.format_exc(), file=file)
+        print("A fatal error occurred: The chip stopped responding.", file=file)
         sys.exit(2)
 
 

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -65,7 +65,7 @@ from esptool.cmds import (
     write_mem,
 )
 from esptool.config import load_config_file
-from esptool.loader import DEFAULT_CONNECT_ATTEMPTS, ESPLoader, list_ports
+from esptool.loader import DEFAULT_CONNECT_ATTEMPTS, REDIRECT_ERROR, ESPLoader, list_ports
 from esptool.targets import CHIP_DEFS, CHIP_LIST, ESP32ROM
 from esptool.util import (
     FatalError,
@@ -166,6 +166,13 @@ def main(argv=None, esp=None):
         ),
         type=int,
         default=os.environ.get("ESPTOOL_CONNECT_ATTEMPTS", DEFAULT_CONNECT_ATTEMPTS),
+    )
+
+    parser.add_argument(
+        "--redirect-errors",
+        help="Redirect errors to stderr instead of stdout",
+        action="store_true",
+        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
     )
 
     subparsers = parser.add_subparsers(
@@ -633,6 +640,7 @@ def main(argv=None, esp=None):
     argv = expand_file_arguments(argv or sys.argv[1:])
 
     args = parser.parse_args(argv)
+    globals()["redirect_errors"] = args.redirect_errors
     print("esptool.py v%s" % __version__)
     load_config_file(verbose=True)
 

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -67,7 +67,7 @@ from esptool.cmds import (
 from esptool.config import load_config_file
 from esptool.loader import (
     DEFAULT_CONNECT_ATTEMPTS,
-    REDIRECT_ERROR,
+    REDIRECT_ERRORS,
     ESPLoader,
     list_ports,
 )
@@ -177,7 +177,7 @@ def main(argv=None, esp=None):
         "--redirect-errors",
         help="Redirect errors to stderr instead of stdout",
         action="store_true",
-        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
+        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
     )
 
     subparsers = parser.add_subparsers(

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -173,13 +173,6 @@ def main(argv=None, esp=None):
         default=os.environ.get("ESPTOOL_CONNECT_ATTEMPTS", DEFAULT_CONNECT_ATTEMPTS),
     )
 
-    parser.add_argument(
-        "--redirect-errors",
-        help="Redirect errors to stderr instead of stdout",
-        action="store_true",
-        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
-    )
-
     subparsers = parser.add_subparsers(
         dest="operation", help="Run esptool.py {command} -h for additional help"
     )
@@ -645,7 +638,6 @@ def main(argv=None, esp=None):
     argv = expand_file_arguments(argv or sys.argv[1:])
 
     args = parser.parse_args(argv)
-    globals()["redirect_errors"] = args.redirect_errors
     print("esptool.py v%s" % __version__)
     load_config_file(verbose=True)
 
@@ -1087,11 +1079,11 @@ def _main():
     except FatalError as e:
         print(
             f"\nA fatal error occurred: {e}",
-            file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+            file=sys.stderr if REDIRECT_ERRORS else sys.stdout,
         )
         sys.exit(2)
     except serial.serialutil.SerialException as e:
-        file = sys.stderr if globals()["redirect_errors"] else sys.stdout
+        file = sys.stderr if REDIRECT_ERRORS else sys.stdout
         print(f"\nA serial exception error occurred: {e}", file=file)
         print(
             "Note: This error originates from pySerial. "
@@ -1106,7 +1098,7 @@ def _main():
         )
         sys.exit(1)
     except StopIteration:
-        file = sys.stderr if globals()["redirect_errors"] else sys.stdout
+        file = sys.stderr if REDIRECT_ERRORS else sys.stdout
         print(traceback.format_exc(), file=file)
         print("A fatal error occurred: The chip stopped responding.", file=file)
         sys.exit(2)

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -1101,7 +1101,7 @@ def _main():
         )
         print(
             "For troubleshooting steps visit: "
-            "https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html",
+            "https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html",  # noqa: E501
             file=file,
         )
         sys.exit(1)

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -1072,23 +1072,25 @@ def _main():
     try:
         main()
     except FatalError as e:
-        print(f"\nA fatal error occurred: {e}")
+        print(f"\nA fatal error occurred: {e}", file=sys.stderr)
         sys.exit(2)
     except serial.serialutil.SerialException as e:
-        print(f"\nA serial exception error occurred: {e}")
+        print(f"\nA serial exception error occurred: {e}", file=sys.stderr)
         print(
             "Note: This error originates from pySerial. "
             "It is likely not a problem with esptool, "
             "but with the hardware connection or drivers."
+            , file=sys.stderr
         )
         print(
             "For troubleshooting steps visit: "
             "https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html"
+            , file=sys.stderr
         )
         sys.exit(1)
     except StopIteration:
-        print(traceback.format_exc())
-        print("A fatal error occurred: The chip stopped responding.")
+        print(traceback.format_exc(), file=sys.stderr)
+        print("A fatal error occurred: The chip stopped responding.", file=sys.stderr)
         sys.exit(2)
 
 

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -65,7 +65,12 @@ from esptool.cmds import (
     write_mem,
 )
 from esptool.config import load_config_file
-from esptool.loader import DEFAULT_CONNECT_ATTEMPTS, REDIRECT_ERROR, ESPLoader, list_ports
+from esptool.loader import (
+    DEFAULT_CONNECT_ATTEMPTS,
+    REDIRECT_ERROR,
+    ESPLoader,
+    list_ports,
+)
 from esptool.targets import CHIP_DEFS, CHIP_LIST, ESP32ROM
 from esptool.util import (
     FatalError,
@@ -1080,7 +1085,10 @@ def _main():
     try:
         main()
     except FatalError as e:
-        print(f"\nA fatal error occurred: {e}", file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
+        print(
+            f"\nA fatal error occurred: {e}",
+            file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+        )
         sys.exit(2)
     except serial.serialutil.SerialException as e:
         file = sys.stderr if globals()["redirect_errors"] else sys.stdout
@@ -1088,13 +1096,13 @@ def _main():
         print(
             "Note: This error originates from pySerial. "
             "It is likely not a problem with esptool, "
-            "but with the hardware connection or drivers."
-            , file=file
+            "but with the hardware connection or drivers.",
+            file=file,
         )
         print(
             "For troubleshooting steps visit: "
-            "https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html"
-            , file=file
+            "https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html",
+            file=file,
         )
         sys.exit(1)
     except StopIteration:

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -67,8 +67,8 @@ from esptool.cmds import (
 from esptool.config import load_config_file
 from esptool.loader import (
     DEFAULT_CONNECT_ATTEMPTS,
-    REDIRECT_ERRORS,
     ESPLoader,
+    REDIRECT_ERRORS,
     list_ports,
 )
 from esptool.targets import CHIP_DEFS, CHIP_LIST, ESP32ROM

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -96,6 +96,8 @@ DEFAULT_SERIAL_WRITE_TIMEOUT = cfg.getfloat("serial_write_timeout", 10)
 DEFAULT_CONNECT_ATTEMPTS = cfg.getint("connect_attempts", 7)
 # Number of times to try writing a data block
 WRITE_BLOCK_ATTEMPTS = cfg.getint("write_block_attempts", 3)
+# Redirect errors to stderr
+REDIRECT_ERROR = cfg.getboolean("redirect_errors", False)
 
 STUBS_DIR = os.path.join(os.path.dirname(__file__), "targets", "stub_flasher")
 

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -97,7 +97,7 @@ DEFAULT_CONNECT_ATTEMPTS = cfg.getint("connect_attempts", 7)
 # Number of times to try writing a data block
 WRITE_BLOCK_ATTEMPTS = cfg.getint("write_block_attempts", 3)
 # Redirect errors to stderr
-REDIRECT_ERROR = cfg.getboolean("redirect_errors", False)
+REDIRECT_ERRORS = cfg.getboolean("redirect_errors", False)
 
 STUBS_DIR = os.path.join(os.path.dirname(__file__), "targets", "stub_flasher")
 

--- a/flasher_stub/esptool_test_stub.py
+++ b/flasher_stub/esptool_test_stub.py
@@ -32,5 +32,5 @@ if __name__ == "__main__":
     try:
         esptool.main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e)
+        print("\nA fatal error occurred: %s" % e, file=sys.stderr)
         sys.exit(2)

--- a/flasher_stub/esptool_test_stub.py
+++ b/flasher_stub/esptool_test_stub.py
@@ -32,5 +32,8 @@ if __name__ == "__main__":
     try:
         esptool.main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e, file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
+        print(
+            "\nA fatal error occurred: %s" % e,
+            file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+        )
         sys.exit(2)

--- a/flasher_stub/esptool_test_stub.py
+++ b/flasher_stub/esptool_test_stub.py
@@ -32,5 +32,5 @@ if __name__ == "__main__":
     try:
         esptool.main()
     except esptool.FatalError as e:
-        print("\nA fatal error occurred: %s" % e, file=sys.stderr)
+        print("\nA fatal error occurred: %s" % e, file=sys.stderr if globals()["redirect_errors"] else sys.stdout)
         sys.exit(2)

--- a/flasher_stub/wrap_stub.py
+++ b/flasher_stub/wrap_stub.py
@@ -13,10 +13,10 @@ import os
 import os.path
 import sys
 
+import esptool  # noqa: E402
 from esptool.loader import REDIRECT_ERROR
 
 sys.path.append("..")
-import esptool  # noqa: E402
 
 THIS_DIR = os.path.dirname(__file__)
 BUILD_DIR = os.path.join(THIS_DIR, "build")

--- a/flasher_stub/wrap_stub.py
+++ b/flasher_stub/wrap_stub.py
@@ -54,7 +54,7 @@ def wrap_stub(elf_file):
             stub.get("data_start", 0),
             stub["entry"],
         ),
-        file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
+        file=sys.stderr if REDIRECT_ERRORS else sys.stdout,
     )
 
     return stub
@@ -80,14 +80,7 @@ def stub_name(filename):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("elf_files", nargs="+", help="Stub ELF files to convert")
-    parser.add_argument(
-        "--redirect-errors",
-        help="Redirect errors to stderr instead of stdout",
-        action="store_true",
-        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
-    )
     args = parser.parse_args()
-    globals()["redirect_errors"] = args.redirect_errors
 
     stubs = dict(
         (stub_name(elf_file), wrap_stub(elf_file)) for elf_file in args.elf_files

--- a/flasher_stub/wrap_stub.py
+++ b/flasher_stub/wrap_stub.py
@@ -13,6 +13,8 @@ import os
 import os.path
 import sys
 
+from esptool.loader import REDIRECT_ERROR
+
 sys.path.append("..")
 import esptool  # noqa: E402
 
@@ -78,7 +80,14 @@ def stub_name(filename):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("elf_files", nargs="+", help="Stub ELF files to convert")
+    parser.add_argument(
+        "--redirect-errors",
+        help="Redirect errors to stderr instead of stdout",
+        action="store_true",
+        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
+    )
     args = parser.parse_args()
+    globals()["redirect_errors"] = args.redirect_errors
 
     stubs = dict(
         (stub_name(elf_file), wrap_stub(elf_file)) for elf_file in args.elf_files

--- a/flasher_stub/wrap_stub.py
+++ b/flasher_stub/wrap_stub.py
@@ -54,7 +54,7 @@ def wrap_stub(elf_file):
             stub.get("data_start", 0),
             stub["entry"],
         ),
-        file=sys.stderr,
+        file=sys.stderr if globals()["redirect_errors"] else sys.stdout,
     )
 
     return stub

--- a/flasher_stub/wrap_stub.py
+++ b/flasher_stub/wrap_stub.py
@@ -14,7 +14,7 @@ import os.path
 import sys
 
 import esptool  # noqa: E402
-from esptool.loader import REDIRECT_ERROR
+from esptool.loader import REDIRECT_ERRORS
 
 sys.path.append("..")
 
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         "--redirect-errors",
         help="Redirect errors to stderr instead of stdout",
         action="store_true",
-        default=os.environ.get("REDIRECT_ERROR", REDIRECT_ERROR),
+        default=os.environ.get("REDIRECT_ERRORS", REDIRECT_ERRORS),
     )
     args = parser.parse_args()
     globals()["redirect_errors"] = args.redirect_errors


### PR DESCRIPTION
Now the exceptions are printed out in the `stderr` instead of `stdout`. That could be a breaking change for some users so here two considerations:

1. make this feature opt-in by a parameter or via `esptool.cfg`
2. the existing scripts can redirect the `stderr` to `stdout` by doing `esptool.py flash_id &> stdout+stderr.txt`

I found this open issue #888 but in my opinion this change can be merged in the current version (`4.7`)