### PR TITLE
add hard reset to rfc2217 server (ESPTOOL-760)

### DIFF
--- a/esp_rfc2217_server.py
+++ b/esp_rfc2217_server.py
@@ -37,7 +37,13 @@ import threading
 import time
 
 from esptool.config import load_config_file
-from esptool.reset import ClassicReset, CustomReset, DEFAULT_RESET_DELAY, UnixTightReset
+from esptool.reset import (
+    ClassicReset,
+    CustomReset,
+    DEFAULT_RESET_DELAY,
+    HardReset,
+    UnixTightReset,
+)
 
 import serial
 import serial.rfc2217
@@ -63,14 +69,23 @@ class EspPortManager(serial.rfc2217.PortManager):
 
     def __init__(self, serial_port, connection, esp32r0_delay, logger=None):
         self.esp32r0_delay = esp32r0_delay
+        self.is_download_mode = False
         super(EspPortManager, self).__init__(serial_port, connection, logger)
 
     def _telnet_process_subnegotiation(self, suboption):
         if suboption[0:1] == COM_PORT_OPTION and suboption[1:2] == SET_CONTROL:
             if suboption[2:3] == SET_CONTROL_DTR_OFF:
+                self.is_download_mode = False
                 self.serial.dtr = False
                 return
-            elif suboption[2:3] == SET_CONTROL_RTS_ON and not self.serial.dtr:
+            elif suboption[2:3] == SET_CONTROL_RTS_OFF and not self.is_download_mode:
+                reset_thread = threading.Thread(target=self._hard_reset_thread)
+                reset_thread.daemon = True
+                reset_thread.name = "hard_reset_thread"
+                reset_thread.start()
+                return
+            elif suboption[2:3] == SET_CONTROL_DTR_ON and not self.is_download_mode:
+                self.is_download_mode = True
                 reset_thread = threading.Thread(target=self._reset_thread)
                 reset_thread.daemon = True
                 reset_thread.name = "reset_thread"
@@ -84,6 +99,14 @@ class EspPortManager(serial.rfc2217.PortManager):
                 return
         # only in cases not handled above do the original implementation in PortManager
         super(EspPortManager, self)._telnet_process_subnegotiation(suboption)
+
+    def _hard_reset_thread(self):
+        """
+        The reset logic used for hard resetting the chip.
+        """
+        if self.logger:
+            self.logger.info("Activating hard reset in thread")
+        HardReset(self.serial)()
 
     def _reset_thread(self):
         """


### PR DESCRIPTION
<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. -->

add hard reset functionality to rfc2217 server and modify bootloader reset to trigger on DTR_ON instead of RTS_ON. This modification allows to use a rfc2217 server with idf_monitor and other compatible serial monitoring tools. 
I'm not a python or rfc2217 expert and was assuming the default reset sequence, so there could be some issues with custom sequences.

# This change fixes the following bug(s):
<!-- If your change fixes any bugs, list them in this section.

Please include the issue URL or the # issue number here. -->

#892

# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.
If you did not perform any testing, write "NO TESTING" in this section. -->

I have tested esp_rfc2217_server.py on windows10 and Ubuntu 22.04.2 LTS using custom esp32-wroom-32 board with the usual automatic bootloader circuit.  

# I have run the esptool.py automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool.py with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. -->

NO TESTING
