### PR TITLE
Remove the shebang from uf2_writer.py (ESPTOOL-781)

### DIFF
--- a/esptool/uf2_writer.py
+++ b/esptool/uf2_writer.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # SPDX-FileCopyrightText: 2020-2023 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: GPL-2.0-or-later
 # Code was originally licensed under Apache 2.0 before the release of ESP-IDF v5.2


### PR DESCRIPTION
This is not a script, so there' no need for it.

I package esptool for Fedora Linux. Our automation has complained that there's a shebang in a file that's not executable. 
Upon inspection it seems so - this file is not intended to be executed directly, hence my proposal to remove the shebang from the file.

# I have tested this change with the following hardware & software combinations:
NO TESTING
