### PR TITLE
fix: Allow the espefuse.py to work when coding scheme == 3 (ESPTOOL-803)

### DIFF
--- a/espefuse/efuse/base_fields.py
+++ b/espefuse/efuse/base_fields.py
@@ -182,7 +182,7 @@ class EfuseBlockBase(EfuseProtectBase):
 
     def get_block_len(self):
         coding_scheme = self.get_coding_scheme()
-        if coding_scheme == self.parent.REGS.CODING_SCHEME_NONE:
+        if coding_scheme == self.parent.REGS.CODING_SCHEME_NONE or coding_scheme == self.parent.REGS.CODING_SCHEME_NONE_RECOVERY:
             return self.len * 4
         elif coding_scheme == self.parent.REGS.CODING_SCHEME_34:
             return (self.len * 3 // 4) * 4

--- a/espefuse/efuse/esp32/fields.py
+++ b/espefuse/efuse/esp32/fields.py
@@ -100,7 +100,7 @@ class EspEfuses(base_fields.EspEfusesBase):
                 EfuseField.convert(self, efuse) for efuse in self.Fields.ADC_CALIBRATION
             ]
         else:
-            if self.coding_scheme == self.REGS.CODING_SCHEME_NONE:
+            if self.coding_scheme == self.REGS.CODING_SCHEME_NONE or self.coding_scheme == self.REGS.CODING_SCHEME_NONE_RECOVERY:
                 self.efuses += [
                     EfuseField.convert(self, efuse)
                     for efuse in self.Fields.KEYBLOCKS_256


### PR DESCRIPTION
When the coding scheme efuse has the value 3, the efuse fields should still be considered to be 256 bits long. Unfortunately, the tool fails miserably with error "A fatal error occurred: Coding scheme (3) not supported"

This patch addresses that by handling the case when coding scheme is 0 in the same way as if coding scheme was 1.

# This change fixes the following bug(s):

# I have tested this change with the following hardware & software combinations:
ESP32 with coding scheme == 3

# I have run the esptool.py automated integration tests with this change and the above hardware:
NO TESTING