### PR TITLE
fix: close file gracefully in espsecure (ESPTOOL-804)

### DIFF
--- a/espsecure/__init__.py
+++ b/espsecure/__init__.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import zlib
 from collections import namedtuple
+from io import IOBase
 
 from cryptography import exceptions
 from cryptography.hazmat.backends import default_backend
@@ -1802,8 +1803,11 @@ def main(custom_commandline=None):
     finally:
         for arg_name in vars(args):
             obj = getattr(args, arg_name)
-            if isinstance(obj, OutFileType):
+            if isinstance(obj, (OutFileType, IOBase)):
                 obj.close()
+            elif isinstance(obj, list):
+                for f in [o for o in obj if isinstance(o, IOBase)]:
+                    f.close()
 
 
 def _main():


### PR DESCRIPTION
The espsecure.py script displays a ResourceWarning error regarding unclosed files when `PYTHONWARNINGS="all"` turns on. This issue arises because espsecure.py utilizes argparse.FileType, which opens a file handler but Python does not automatically handle the close() operation.

``` python
% PYTHONWARNINGS="all" espsecure.py sign_data --version 1 --keyfile keys.pem  --output signed.bin input.bin
espsecure.py v4.7.0
Signed 1032336 bytes of data from input.bin
/dev/.venv/lib/python3.11/site-packages/espsecure/__init__.py:1828: ResourceWarning: unclosed file <_io.BufferedReader name='keys.pem'>
  main()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/dev/.venv/lib/python3.11/site-packages/espsecure/__init__.py:1828: ResourceWarning: unclosed file <_io.BufferedReader name='input.bin'>
  main()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

This fix is to handle the close() explicitly to have a gracefully exit and avoid memory leaks.