### PR TITLE
Image2hex (ESPTOOL-818)

### DIFF
--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "flash_id",
     "get_security_info",
     "image_info",
+    "image2hex"
     "load_ram",
     "make_image",
     "merge_bin",
@@ -51,6 +52,7 @@ from esptool.cmds import (
     flash_id,
     get_security_info,
     image_info,
+    image2hex,
     load_ram,
     make_image,
     merge_bin,
@@ -376,6 +378,16 @@ def main(argv=None, esp=None):
         help="Output format version (1 - legacy, 2 - extended)",
         choices=["1", "2"],
         default="1",
+    )
+
+    parser_image2hex = subparsers.add_parser(
+        "image2hex", help="Convert image to intel hex"
+    )
+    parser_image2hex.add_argument(
+        "inImage", help="Image file to parse"
+    )
+    parser_image2hex.add_argument(
+        "outHex", help="Hex file to generate (processor type and entry point will be added to this filename)"
     )
 
     parser_make_image = subparsers.add_parser(

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -963,6 +963,59 @@ def image_info(args):
         pass  # ESP8266 image has no append_digest field
 
 
+def image2hex(args):
+    with open(args.inImage, "rb") as f:
+        # magic number
+        try:
+            common_header = f.read(8)
+            magic = common_header[0]
+        except IndexError:
+            raise FatalError("File is empty")
+        if magic not in [
+            ESPLoader.ESP_IMAGE_MAGIC,
+            ESP8266V2FirmwareImage.IMAGE_V2_MAGIC,
+        ]:
+            raise FatalError(
+                "This is not a valid image " "(invalid magic number: {:#x})".format(
+                    magic
+                )
+            )
+
+        if args.chip == "auto":
+            try:
+                extended_header = f.read(16)
+
+                # append_digest, either 0 or 1
+                if extended_header[-1] not in [0, 1]:
+                    raise FatalError("Append digest field not 0 or 1")
+
+                chip_id = int.from_bytes(extended_header[4:5], "little")
+                for rom in [n for n in ROM_LIST if n.CHIP_NAME != "ESP8266"]:
+                    if chip_id == rom.IMAGE_CHIP_ID:
+                        args.chip = rom.CHIP_NAME
+                        break
+                else:
+                    raise FatalError(f"Unknown image chip ID ({chip_id})")
+            except FatalError:
+                args.chip = "esp8266"
+
+            print(f"Detected image type: {args.chip.upper()}")
+
+    image = LoadFirmwareImage(args.chip, args.inImage)
+
+    if args.outHex.endswith(".hex"):
+        args.outHex = args.outHex[:-4]
+
+    args.outHex += "_{}_entry_0x{:08x}.hex".format(args.chip, image.entrypoint)
+
+    ih = IntelHex()
+
+    for seg in image.segments:
+        ih.frombytes(seg.data, seg.addr)
+
+    ih.write_hex_file(args.outHex, byte_count = 32)
+
+
 def make_image(args):
     print("Creating {} image...".format(args.chip))
     image = ESP8266ROMFirmwareImage()


### PR DESCRIPTION
This modification adds a function image2hex which will parse an image and generate an intel hex file containing all segments from the provided image.

# I have tested this change with the following hardware & software combinations:
Windows 11, ESP32C3 SuperMini

# I have run the esptool.py automated integration tests with this change and the above hardware:
NO TESTING