### PR TITLE
Hex2image (ESPTOOL-817)

### DIFF
--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -382,14 +382,18 @@ def main(argv=None, esp=None):
         "make_image", help="Create an application image from binary files"
     )
     parser_make_image.add_argument("output", help="Output image file")
-    parser_make_image.add_argument(
+    parser_make_image_input = parser_make_image.add_mutually_exclusive_group(required=True)
+    parser_make_image_input.add_argument(
         "--segfile", "-f", action="append", help="Segment input file"
+    )
+    parser_make_image_input.add_argument(
+        "--hexfile", "-x", help="Hex input file"
     )
     parser_make_image.add_argument(
         "--segaddr",
         "-a",
         action="append",
-        help="Segment base address",
+        help="Segment base address (unused for hexfile input)",
         type=arg_auto_int,
     )
     parser_make_image.add_argument(

--- a/esptool/bin_image.py
+++ b/esptool/bin_image.py
@@ -689,10 +689,13 @@ class ESP32FirmwareImage(BaseFirmwareImage):
             # So bootdesc will be at the very top of the binary at 0x20 offset
             # (in the first segment).
             for segment in ram_segments:
-                if segment.name == ".dram0.bootdesc":
-                    ram_segments.remove(segment)
-                    ram_segments.insert(0, segment)
-                    break
+                try:
+                    if segment.name == ".dram0.bootdesc":
+                        ram_segments.remove(segment)
+                        ram_segments.insert(0, segment)
+                        break
+                except:
+                    pass
 
             # check for multiple ELF sections that are mapped in the same
             # flash mapping region. This is usually a sign of a broken linker script,


### PR DESCRIPTION
This change adds the possibility to convert a hex file to an image file with make_image. It also allows to create images for other targets then ESP8266.

# I have tested this change with the following hardware & software combinations:
Windows 11, ESP32C3 SuperMini

# I have run the esptool.py automated integration tests with this change and the above hardware:
NO TESTING
