### PR TITLE
docs(flashing): Fixed a typo in /docs/en/esptool/flashing-firmware.rst (ESPTOOL-852)

### DIFF
--- a/docs/en/esptool/flashing-firmware.rst
+++ b/docs/en/esptool/flashing-firmware.rst
@@ -8,7 +8,7 @@ Flashing Firmware
 Esptool is used under the hood of many development frameworks for Espressif SoCs, such as `ESP-IDF <https://docs.espressif.com/projects/esp-idf/>`_, `Arduino <https://docs.espressif.com/projects/arduino-esp32/>`_, or `PlatformIO <https://docs.platformio.org/en/latest/platforms/espressif32.html>`_.
 After the resulting firmware binary files are compiled, esptool is used to flash these into the device.
 
-Sometimes there might be a need to comfortably flash a bigger amount of decives with the same binaries or to share flashing instructions with a third party.
+Sometimes there might be a need to comfortably flash a bigger amount of devices with the same binaries or to share flashing instructions with a third party.
 It is possible to compile the firmware just once and then repeatedly use esptool (manually or :ref:`in a custom script <scripting>`) to flash the files.
 
 Sharing these instructions and below mentioned assets with a third party (for example a manufacturer) should suffice to allow reproducible and quick flashing of your application into an Espressif chip.


### PR DESCRIPTION
Updated the text in this file to fix a typo which was decives, that is now devices.

<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. --> So sorry about the multiple PRS, I'm not fully up to date with good git practices.

# This change fixes the following bug(s): Fixed Spelling Mistake In /docs/en/esptool/flashing-firmware.rst
<!-- If your change fixes any bugs, list them in this section.

Please include the issue URL or the # issue number here. --> n/a

# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.

If you did not perform any testing, write "NO TESTING" in this section. -->NO TESTING

# I have run the esptool.py automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool.py with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. --> NO TESTING
