### PR TITLE
Fix typos (ESPTOOL-853)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,8 +144,10 @@ host_tests_hsm:
     PYTEST_ADDOPTS: "-sv --junitxml=test/report.xml --color=yes"
   before_script:
     - apt-get update
-    - apt-get install -y python3 python3-pip softhsm2
+    - apt-get install -y python3 python3-pip python3-venv softhsm2
     - ./ci/setup_softhsm2.sh || exit 1
+    - python3 -m venv esptoolenv
+    - source esptoolenv/bin/activate
     - pip3 install -e .[dev,hsm] --prefer-binary
   script:
     - coverage run --parallel-mode -m pytest ${CI_PROJECT_DIR}/test/test_espsecure_hsm.py

--- a/docs/en/esptool/flashing-firmware.rst
+++ b/docs/en/esptool/flashing-firmware.rst
@@ -8,7 +8,7 @@ Flashing Firmware
 Esptool is used under the hood of many development frameworks for Espressif SoCs, such as `ESP-IDF <https://docs.espressif.com/projects/esp-idf/>`_, `Arduino <https://docs.espressif.com/projects/arduino-esp32/>`_, or `PlatformIO <https://docs.platformio.org/en/latest/platforms/espressif32.html>`_.
 After the resulting firmware binary files are compiled, esptool is used to flash these into the device.
 
-Sometimes there might be a need to comfortably flash a bigger amount of decives with the same binaries or to share flashing instructions with a third party.
+Sometimes there might be a need to comfortably flash a bigger amount of devices with the same binaries or to share flashing instructions with a third party.
 It is possible to compile the firmware just once and then repeatedly use esptool (manually or :ref:`in a custom script <scripting>`) to flash the files.
 
 Sharing these instructions and below mentioned assets with a third party (for example a manufacturer) should suffice to allow reproducible and quick flashing of your application into an Espressif chip.

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -116,7 +116,7 @@ def detect_chip(
         else:
             err_msg = f"Unexpected chip ID value {chip_id}."
     except (UnsupportedCommandError, struct.error, FatalError) as e:
-        # UnsupportedCommmanddError: ESP8266/ESP32 ROM
+        # UnsupportedCommandError: ESP8266/ESP32 ROM
         # struct.error: ESP32-S2
         # FatalError: ESP8266/ESP32 STUB
         print(" Unsupported detection protocol, switching and trying again...")


### PR DESCRIPTION
Just fix typos in comment.

# I have tested this change with the following hardware & software combinations:
NO TESTING

# I have run the esptool.py automated integration tests with this change and the above hardware:
NO TESTING