### PR TITLE
docs(flashing): Update error when connecting to serial port fails on linux (ESPTOOL-874)

### DIFF
--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -336,8 +336,9 @@ class ESPLoader(object):
                         [  # permission denied error
                             re.compile(r"Permission denied", re.IGNORECASE),
                             (
-                                "Try to add user into dialout group: "
-                                "sudo usermod -a -G dialout $USER"
+                                "Try to add user into a group that has serial port permissions: "
+                                "Ubuntu and ubuntu-based: sudo usermod -a -G dialout $USER"
+                                "Arch: sudo usermod -a -G uucp $USER"
                             ),
                         ],
                     )


### PR DESCRIPTION
This pull request makes more description on linux based systems when esptool cant connect to the serial port defined by the user.

# This change fixes the following bug(s):

# I have tested this change with the following hardware & software combinations:
Tested on Arch, Ubuntu 22.04 and 20.04 and Windows 10

# I have run the esptool.py automated integration tests with this change and the above hardware:
NO TESTING
