### PR TITLE
feat(esptool): allow filtering ports by VID/PID (ESPTOOL-878)

### DIFF
--- a/docs/en/esptool/advanced-options.rst
+++ b/docs/en/esptool/advanced-options.rst
@@ -117,3 +117,21 @@ An example of this is available in the :ref:`merge_bin <merge-bin>` command desc
 .. note:: PowerShell users
 
     Because of `splatting <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_splatting?view=powershell-7.3>`__ in PowerShell (method of passing a collection of parameter values to a command as a unit) there is a need to add quotes around @filename.txt ("@filename.txt") to be correctly resolved.
+
+Filtering serial ports
+----------------------
+.. _filtering_serial_ports:
+
+``--port-filter <FilterType>=<FilterValue>`` allows limiting ports that will be tried. This can be useful when esptool is run on a system
+with many serial ports. There are a few different types that can be combined. A port must match all specified FilterTypes, and must match
+at least one FilterValue for each specified FilterType to be considered. Example filter configurations:
+
+.. list::
+
+    * ``--port-filter vid=0x303A`` matches ports with the Espressif USB VID.
+    * ``--port-filter vid=0x303A --port-filter vid=0x0403`` matches Espressif and FTDI ports by VID.
+    * ``--port-filter vid=0x303A --port-filter pid=0x0002`` matches Espressif ESP32-S2 in USB-OTG mode by VID and PID.
+    * ``--port-filter vid=0x303A --port-filter pid=0x1001`` matches Espressif USB-Serial/JTAG unit used by multiple chips by VID and PID.
+    * ``--port-filter name=ttyUSB`` matches ports where the port name contains the specified text.
+
+See also the `Espressif USB customer-allocated PID repository <https://github.com/espressif/usb-pids>`_


### PR DESCRIPTION
Enables user to specify --usbVid and/or --usbPid, which filter the com port list before checking for ESP chips. With many serial ports on the computer, this greatly speeds up the process of esptool identifying the correct com port by allowing esptool to skip all com ports without a matching VID/PID. Implements https://github.com/espressif/esptool/issues/987

# I have tested this change with the following hardware & software combinations:

NO TESTING ON MAC/LINUX. Tested on Windows64 with ESP32-S3-DevKitC and custom ESP32-S3 board.

```
$ time esptool read_flash_status
esptool.py v4.7.0
Found 4 serial ports
Serial port COM30
Connecting......................................
COM30 failed to connect: Failed to connect to Espressif device: No serial data received.
For troubleshooting steps visit: https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html
Serial port COM29
Connecting......................................
COM29 failed to connect: Failed to connect to Espressif device: No serial data received.
For troubleshooting steps visit: https://docs.espressif.com/projects/esptool/en/latest/troubleshooting.html
Serial port COM18
Connecting...
Detecting chip type... ESP32-S3
...long text omitted...
real    0m18.193s
user    0m0.000s
sys     0m0.015s
```

```
$ time esptool --usbVid 0x303a read_flash_status
esptool.py v4.7.0
Found 1 serial ports
Serial port COM18
Connecting...
Detecting chip type... ESP32-S3
...long text omitted...
real    0m1.067s
user    0m0.000s
sys     0m0.000s
```



# I have run the esptool.py automated integration tests with this change and the above hardware:

$ pytest test_esptool.py --port COM49 --chip esp32s3 --baud 230400
============================= test session starts =============================
platform win32 -- Python 3.11.5, pytest-8.2.2, pluggy-1.5.0
rootdir: C:\Projects\esptool
configfile: pyproject.toml
collected 88 items

test_esptool.py sss.......ss.................s.s.........s....sss.s..... [ 63%]
......s...sssssss..ssss..s..ssss                                         [100%]

============================== warnings summary ===============================
test_esptool.py:120
  C:\Projects\esptool\test\test_esptool.py:120: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=1, condition=arg_preload_port is not False)

test_esptool.py:1204
  C:\Projects\esptool\test\test_esptool.py:1204: PytestUnknownMarkWarning: Unknown pytest.mark.flaky - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.flaky(reruns=5)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 59 passed, 29 skipped, 2 warnings in 415.91s (0:06:55) ============
