### PR TITLE
Proposed Edit to Minimize Future Upload Errors (ESPTOOL-879)

### DIFF
--- a/docs/en/advanced-topics/boot-mode-selection.rst
+++ b/docs/en/advanced-topics/boot-mode-selection.rst
@@ -164,6 +164,7 @@ Manual Bootloader
 Depending on the kind of hardware you have, it may also be possible to manually put your {IDF_TARGET_NAME} board into Firmware Download mode (reset).
 
 - For development boards produced by Espressif, this information can be found in the respective getting started guides or user guides. For example, to manually reset a development board, hold down the **Boot** button (``{IDF_TARGET_STRAP_BOOT_GPIO}``) and press the **EN** button (``EN`` (``CHIP_PU``)).
+- Note: Only release **Boot** button when connection is established.
 - For other types of hardware, try pulling ``{IDF_TARGET_STRAP_BOOT_GPIO}`` down.
 
 .. only:: esp8266


### PR DESCRIPTION
Based on community forums and personal experience, I propose an edit to the documentation/code to help minimize future errors during code uploads. This change aims to clarify that, in at least some implementations of the chip, it is necessary to hold the boot button until the connection is established when attempting to upload code or firmware.

I apologize if this change is deemed unnecessary, but I believe it will help prevent potential issues for users.

Thank you for considering this request.
Best regards,
João GF

<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. -->

# This change fixes the following bug(s):
<!-- If your change fixes any bugs, list them in this section.

Please include the issue URL or the # issue number here. -->

# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.

If you did not perform any testing, write "NO TESTING" in this section. -->

# I have run the esptool.py automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool.py with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. -->
