### PR TITLE
feat(esptool): Add --retry-open-serial flag, config file entry and envar (ESPTOOL-890)

### DIFF
--- a/docs/en/esptool/configuration-file.rst
+++ b/docs/en/esptool/configuration-file.rst
@@ -109,7 +109,7 @@ Complete list configurable options:
 +------------------------------+-----------------------------------------------------------+----------+
 | custom_reset_sequence        | Custom reset sequence for resetting into the bootloader   |          |
 +------------------------------+-----------------------------------------------------------+----------+
-| retry_open_serial            | Retry opening the serial port indefinitely                   | False    |
+| retry_open_serial            | Retry opening the serial port indefinitely                | False    |
 +------------------------------+-----------------------------------------------------------+----------+
 
 Custom Reset Sequence

--- a/docs/en/esptool/configuration-file.rst
+++ b/docs/en/esptool/configuration-file.rst
@@ -109,6 +109,8 @@ Complete list configurable options:
 +------------------------------+-----------------------------------------------------------+----------+
 | custom_reset_sequence        | Custom reset sequence for resetting into the bootloader   |          |
 +------------------------------+-----------------------------------------------------------+----------+
+| retry_open_serial            | Retry opening the serial port indefinitely                   | False    |
++------------------------------+-----------------------------------------------------------+----------+
 
 Custom Reset Sequence
 ---------------------

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -67,7 +67,13 @@ from esptool.cmds import (
     write_mem,
 )
 from esptool.config import load_config_file
-from esptool.loader import DEFAULT_CONNECT_ATTEMPTS, StubFlasher, ESPLoader, list_ports, cfg
+from esptool.loader import (
+    DEFAULT_CONNECT_ATTEMPTS,
+    StubFlasher,
+    ESPLoader,
+    list_ports,
+    cfg,
+)
 from esptool.targets import CHIP_DEFS, CHIP_LIST, ESP32ROM
 from esptool.util import (
     FatalError,
@@ -188,16 +194,6 @@ def main(argv=None, esp=None):
         ),
         type=int,
         default=os.environ.get("ESPTOOL_CONNECT_ATTEMPTS", DEFAULT_CONNECT_ATTEMPTS),
-    )
-
-    parser.add_argument(
-        "--retry-open-serial",
-        help=(
-            "Retry opening the serial port indefinitely. "
-            "Default: %s" % DEFAULT_RETRY_OPEN_SERIAL
-        ),
-        default=os.environ.get("ESPTOOL_RETRY_OPEN_SERIAL", DEFAULT_RETRY_OPEN_SERIAL),
-        action="store_true",
     )
 
     subparsers = parser.add_subparsers(
@@ -782,7 +778,9 @@ def main(argv=None, esp=None):
             port=args.port,
             connect_attempts=args.connect_attempts,
             initial_baud=initial_baud,
-            retry_open_serial=args.retry_open_serial,
+            retry_open_serial=os.environ.get(
+                "ESPTOOL_RETRY_OPEN_SERIAL", DEFAULT_RETRY_OPEN_SERIAL
+            ),
             chip=args.chip,
             trace=args.trace,
             before=args.before,
@@ -1142,7 +1140,6 @@ def get_default_specific_connected_device(
                     print(".", end="", flush=True)
             time.sleep(0.1)
             retry_attempts += 1
-            continue
 
 
 def get_default_connected_device(
@@ -1171,7 +1168,7 @@ def get_default_connected_device(
                     trace,
                     before,
                     connect_attempts,
-                    retry_open_serial,
+                    retry_open_serial and port is not None,
                 )
             break
         except (FatalError, OSError) as err:

--- a/esptool/config.py
+++ b/esptool/config.py
@@ -20,6 +20,7 @@ CONFIG_OPTIONS = [
     "write_block_attempts",
     "reset_delay",
     "custom_reset_sequence",
+    "retry_open_serial",
 ]
 
 


### PR DESCRIPTION
`esptool` frequently fails when trying to open the serial port of a device which deep-sleeps often:

```
$ esptool.py --chip esp32s3 -p /dev/cu.usbmodem6101 [...] write_flash foo.bin Serial port /dev/cu.usbmodem6101

A fatal error occurred: Could not open /dev/cu.usbmodem6101, the port is busy or doesn't exist.
([Errno 35] Could not exclusively lock port [...]: [Errno 35] Resource temporarily unavailable)
```

This makes developers add [unnecessarily long sleeps](https://github.com/espressif/esp-idf/blob/9d41418bd25a08daf7b0b0bc95d864c11261777a/examples/system/ulp/lp_core/gpio/main/lp_core_gpio_example_main.c#L38)when the main CPU is awake, in order to give `esptool` the chance to find the serial port.

This PR adds a new flag `--retry-open-serial` (with corresponding env variable and cfg file entry) which retries opening the port indefinitely until the device shows up:

```
$ esptool.py --chip esp32s3 -p /dev/cu.usbmodem6101 [...] write_flash --retry-open-serial foo.bin Serial port /dev/cu.usbmodem6101
[Errno 35] Could not exclusively lock port [...]: [Errno 35] Resource temporarily unavailable Retrying to open port .........................
Connecting....
Chip is ESP32-S3 (QFN56) (revision v0.2)
[...]
```

# I have tested this change with the following hardware & software combinations:

ESP32S3 + esptool master branch


# I have run the esptool.py automated integration tests with this change and the above hardware:

 "NO TESTING" (I can do so if considered necessary in order to merge)
 
 I did test the flag, the env variable and the config file entry though.

