### PR TITLE
Fix Warning Handling in `_check_if_can_reset` Method (ESPTOOL-894)

### DIFF
--- a/esptool/targets/esp32s2.py
+++ b/esptool/targets/esp32s2.py
@@ -5,6 +5,7 @@
 
 import os
 import struct
+import warnings
 from typing import Dict
 
 from .esp32 import ESP32ROM
@@ -296,15 +297,15 @@ class ESP32S2ROM(ESP32ROM):
             strap_reg & self.GPIO_STRAP_SPI_BOOT_MASK == 0
             and force_dl_reg & self.RTC_CNTL_FORCE_DOWNLOAD_BOOT_MASK == 0
         ):
-            print(
+            warnings.warn(
                 "WARNING: {} chip was placed into download mode using GPIO0.\n"
                 "esptool.py can not exit the download mode over USB. "
                 "To run the app, reset the chip manually.\n"
                 "To suppress this note, set --after option to 'no_reset'.".format(
                     self.get_chip_description()
-                )
+                ),
+                UserWarning
             )
-            raise SystemExit(1)
 
     def hard_reset(self):
         uses_usb_otg = self.uses_usb_otg()

--- a/esptool/targets/esp32s3.py
+++ b/esptool/targets/esp32s3.py
@@ -5,6 +5,7 @@
 
 import os
 import struct
+import warnings
 from typing import Dict
 
 from .esp32 import ESP32ROM
@@ -358,15 +359,15 @@ class ESP32S3ROM(ESP32ROM):
             strap_reg & self.GPIO_STRAP_SPI_BOOT_MASK == 0
             and force_dl_reg & self.RTC_CNTL_FORCE_DOWNLOAD_BOOT_MASK == 0
         ):
-            print(
+            warnings.warn(
                 "WARNING: {} chip was placed into download mode using GPIO0.\n"
                 "esptool.py can not exit the download mode over USB. "
                 "To run the app, reset the chip manually.\n"
                 "To suppress this note, set --after option to 'no_reset'.".format(
                     self.get_chip_description()
-                )
+                ),
+                UserWarning
             )
-            raise SystemExit(1)
 
     def hard_reset(self):
         uses_usb_otg = self.uses_usb_otg()


### PR DESCRIPTION
<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. -->

### Description of Change
This change modifies the `_check_if_can_reset` method to issue a warning instead of raising a `SystemExit` when the chip is in download mode using GPIO0. This ensures that the method behaves as intended by only issuing a warning without terminating the program.

### Bug Fixes
This change fixes the following bug:
- [#996](https://github.com/espressif/esptool/issues/996)

### Hardware & Software Combinations Tested
I have tested this change with the following hardware & software combinations:
- **Operating System**: Windows 10
- **Development Board**: ESP32-S2
- **Baud Rate**: 115200

### Automated Integration Tests
I have run the `esptool.py` automated integration tests with this change and the above hardware:
- **Results**: 60 tests passed, 29 tests skipped

```sh
pytest test_esptool.py --port COM4 --chip esp32s2 --baud 115200
