### PR TITLE
ci(pypi_release): Use build --sdist argument to avoid building non-universal whl (ESPTOOL-926)

### DIFF
--- a/.github/workflows/dev_release_esptool_pypi.yml
+++ b/.github/workflows/dev_release_esptool_pypi.yml
@@ -36,5 +36,5 @@ jobs:
         python -m pip download esptool==$(python setup.py -V) && echo "Version ${{ github.ref_name }} already published, skipping..." && exit 1
 
         echo "Packaging and publishing new esptool development release: ${{ github.ref_name }}"
-        python -m build
+        python -m build --sdist
         twine upload dist/*

--- a/.github/workflows/release_esptool_pypi.yml
+++ b/.github/workflows/release_esptool_pypi.yml
@@ -34,6 +34,6 @@ jobs:
           exit 1
         else
           echo "Packaging and publishing new esptool version: ${CURRENT_VERSION}"
-          python -m build
+          python -m build --sdist
           twine upload dist/*
         fi


### PR DESCRIPTION
<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. -->
https://github.com/espressif/esptool/commit/eacc94a386267ad39de876f29b7bd1a6823387ae changed from using 
python setup.py sdist 
to 
python -m build

The latter now builds a .whl which got uploaded using twine on the 4.8.0 release (https://pypi.org/project/esptool/4.8.0/#files)

Unfortuatnely due to setup.py (https://github.com/espressif/esptool/blob/master/setup.py),
the whl that is built on ubuntu uses scripts instead of entry_points
This makes the whl incompatible with Windows systems and causes import error / no exe's created
See https://github.com/espressif/esptool/issues/1010

This change adds --sdist argument to build which tells it not to create the whl.
This allows all systems to just use the source and then do the correct setup.py behaviour

# This change fixes the following bug(s):
<!-- If your change fixes any bugs, list them in this section.
Please include the issue URL or the # issue number here. -->
https://github.com/espressif/esptool/issues/1010

# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.
If you did not perform any testing, write "NO TESTING" in this section. -->
I have tested build --sdist locally in Ubuntu and then installing the results .tar.gz in both windows and ubuntu

# I have run the esptool.py automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool.py with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. -->
NO TESTING