### PR TITLE
[packaging] Exclude also the submodules of test and docs (ESPTOOL-927)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@
     "*" = ["esptool/targets/stub_flasher/1/*", "esptool/targets/stub_flasher/2/*"]
 
 [tool.setuptools.packages]
-    find = {exclude = ["ci", "flasher_stub", "test", "docs"]}
+    find = {exclude = ["ci*", "test*", "docs*"]}
 
 [tool.setuptools.dynamic]
     version = {attr = "esptool.__init__.__version__"}


### PR DESCRIPTION
When running the wheel build of esptool 4.8.0 in Fedora, the `docs/en/conf.py` and `test/efuse_scripts/*.py` were included in the distribution.

Apparently, setuptools excludes only the first level of modules, unless specified otherwise. Following the official documentation, the `Important` part, adding asterisks to exclude all the found submodules does the trick
https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-simple-packages

I've tested it during the Fedora RPM build and verified this change works for us.
