### PR TITLE
image_info: add -x option to extract segments to disk (ESPTOOL-947)

### DIFF
--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -403,6 +403,11 @@ def main(argv=None, esp=None):
         default="1",
     )
 
+    parser_image_info.add_argument(
+        '--extract', '-x', action='store_true',
+        help='Extract image segments to files'
+    )
+
     parser_make_image = subparsers.add_parser(
         "make_image", help="Create an application image from binary files"
     )

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -1011,6 +1011,13 @@ def image_info(args):
         segs = seg.get_memory_type(image)
         seg_name = ",".join(segs)
         print("Segment {}: {} [{}]".format(idx, seg, seg_name))
+        if args.extract:
+            # Create filename for the extracted segment
+            filename = f"/tmp/seg{idx}_len0x{len(seg.data):x}_addr0x{seg.addr:x}"
+            with open(filename, "wb") as f:
+                f.write(seg.data)
+            print(f"  Extracted to: {filename}")
+
     calc_checksum = image.calculate_checksum()
     print(
         "Checksum: {:02x} ({})".format(


### PR DESCRIPTION
This adds ability to extract the segments from an image to disk. This can be useful for later analysis or modification, and was easy enough to add.

Pass -x to image_info. Destination directory is /tmp, file naming contains some metadata to make life easier.

# I have tested this change with the following hardware & software combinations:

ESP32 firmware

# I have run the esptool.py automated integration tests with this change and the above hardware:
None yet
