### PR TITLE
feat(macos-amd64): Add Intel-based macOS as target (ESPTOOL-957)

### DIFF
--- a/.github/workflows/build_esptool.yml
+++ b/.github/workflows/build_esptool.yml
@@ -8,12 +8,16 @@ jobs:
     runs-on: ${{ matrix.RUN_ON }}
     strategy:
       matrix:
-        platform: [macos, windows, linux-amd64, linux-arm32, linux-arm64]
+        platform: [macos-amd64, macos-arm64, windows, linux-amd64, linux-arm32, linux-arm64]
         include:
-        - platform: macos
-          TARGET: macos
+        - platform: macos-amd64
+          TARGET: macos-amd64
           SEPARATOR: ':'
-          RUN_ON: macos-latest
+          RUN_ON: macos-13 # Versions 13 and lower are Intel-based.
+        - platform: macos-arm64
+          TARGET: macos-arm64
+          SEPARATOR: ':'
+          RUN_ON: macos-latest # Versions 14 and higher are ARM-based.
         - platform: windows
           TARGET: win64
           EXTEN: .exe


### PR DESCRIPTION
Arduino and many other applications still require `x86_64` binaries for MacOS. We will need these binaries for releasing important updates like ESP32-P4 support in Arduino.

This PR adds the `macos-amd64` target for the esptool, making it available to Intel-based CPUs on MacOS.

Ideally the current `macos` target should be renamed to `macos-arm64` for consistency but it will be a breaking change, so it can be postponed until a new major release.

# This change fixes the following bug(s):

No recent available esptool for MacOS Intel CPUs.

# I have run the esptool.py automated integration tests with this change and the above hardware:

Tested in fork with CI.
