### PR TITLE
docs: Correct instruction to run (ESPTOOL-1003)

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -29,11 +29,11 @@ Getting started is easy:
 
 2) Connect an Espressif chip to your computer.
 
-3) Run ``esptool.py`` commands. For example, to read information about your chip's SPI flash, run:
+3) Invoke ``esptool`` module with commands. For example, to read information about your chip's SPI flash, run:
 
     ::
 
-        $ esptool.py -p PORT flash_id
+        $ python -m esptool -p PORT flash_id
 
     Replace ``PORT`` with the name of used serial port. If connection fails, see :ref:`troubleshooting`.
 


### PR DESCRIPTION
Previous command `python esptool.py` would only work if the repo is cloned, with instruction above in the documentation to install the pip package, it makes more sense to invoke the module and run the tool as follows.

```
python -m esptool -p PORT flash_id
```

# This change fixes the following bug(s):
Make instructions clearer and easier to understand.

# I have tested this change with the following hardware & software combinations:
NO TESTING

# I have run the esptool.py automated integration tests with this change and the above hardware:
NO TESTING
