### PR TITLE
encapsulate sys.stdout.flush() into logger, guard against None sys.stdout (ESPTOOL-1008)

### DIFF
--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -140,7 +140,7 @@ def detect_chip(
                     connect_mode, connect_attempts, detecting=True, warnings=False
                 )
             log.print("Detecting chip type...", end="")
-            sys.stdout.flush()
+            log.flush()
             chip_magic_value = detect_port.read_reg(
                 ESPLoader.CHIP_DETECT_MAGIC_REG_ADDR
             )
@@ -183,7 +183,7 @@ def load_ram(esp, args):
     for seg in image.segments:
         size = len(seg.data)
         log.print(f"Downloading {size} bytes at {seg.addr:08x}...", end=" ")
-        sys.stdout.flush()
+        log.flush()
         esp.mem_begin(
             size, div_roundup(size, esp.ESP_RAM_BLOCK), esp.ESP_RAM_BLOCK, seg.addr
         )
@@ -218,7 +218,7 @@ def dump_mem(esp, args):
                 percent = f.tell() * 100 // args.size
                 log.set_progress(percent)
                 log.print_overwrite(f"{f.tell()} bytes read... ({percent} %)")
-            sys.stdout.flush()
+            log.flush()
         log.print_overwrite(f"Read {f.tell()} bytes", last_line=True)
     log.print("Done!")
 
@@ -643,7 +643,7 @@ def write_flash(esp, args):
                         "Writing at 0x%08x... (%d %%)"
                         % (address + bytes_written, percent)
                     )
-                    sys.stdout.flush()
+                    log.flush()
                     block = image[0 : esp.FLASH_WRITE_SIZE]
                     if compress:
                         # feeding each compressed block into the decompressor lets us
@@ -697,7 +697,7 @@ def write_flash(esp, args):
                         break
                     except SerialException:
                         log.print(".", end="")
-                        sys.stdout.flush()
+                        log.flush()
                 else:
                     raise  # Reconnect limit reached
 

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -629,7 +629,7 @@ class ESPLoader(object):
                 return None
             except FatalError as e:
                 log.print(".", end="")
-                sys.stdout.flush()
+                log.flush()
                 time.sleep(0.05)
                 last_error = e
 
@@ -723,7 +723,7 @@ class ESPLoader(object):
             )
 
         log.print("Connecting...", end="")
-        sys.stdout.flush()
+        log.flush()
         last_error = None
 
         reset_sequence = self._construct_reset_strategy_sequence(mode)

--- a/esptool/logger.py
+++ b/esptool/logger.py
@@ -49,6 +49,12 @@ class TemplateLogger(ABC):
         """
         pass
 
+    @abstractmethod
+    def flush():
+        """
+        Flushes the current loging to stdout
+        """
+        pass
 
 class EsptoolLogger(TemplateLogger):
     ansi_red = "\033[1;31m"
@@ -130,6 +136,14 @@ class EsptoolLogger(TemplateLogger):
         Percentage is a float between 0 and 100.
         """
         pass
+
+    @abstractmethod
+    def flush():
+        try:
+            sys.stdout.flush()
+        except AttributeError:
+            # to handle certain contexts where sys.stdout is not available (None)
+            pass
 
     def set_logger(self, new_logger):
         self.__class__ = new_logger.__class__


### PR DESCRIPTION
# This change fixes the following bug(s):
fix(esptool/all) : Encapsulates sys.stdout.flush() in logger, with a guard if stdout is not valid (e.g. None)

Resolves https://github.com/espressif/esptool/issues/1063

We are using esptool to flash firmware in the context of our app. 

This app runs on Kivy, and built with Pyinstaller. On windows, it appears that sys.stdout is not available (sys.stdout is None)

Under these conditions, esptool will crash when sys.stdout.flush() is called

What is the Expected Behaviour?

esptool should guard against this condition and not crash if sys.stdout is not available.



Encapsulates sys.stdout.flush() in logger, with a guard if stdout is not valid (e.g. None)