### PR TITLE
clean up port if get_esp fails

### DIFF
--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -90,9 +90,13 @@ def get_esp(
                 port if not skip_connect else StringIO(), baud
             )
             if not skip_connect:
-                esp.connect(connect_mode)
-                if esp.sync_stub_detected:
-                    esp = esp.STUB_CLASS(esp)
+                try:
+                    esp.connect(connect_mode)
+                    if esp.sync_stub_detected:
+                        esp = esp.STUB_CLASS(esp)
+                except Exception as e:
+                    esp._port.close()
+                    raise e
     return esp
 
 


### PR DESCRIPTION
When using `esptool` as part of a python script that automates chip provisioning, it is important that the ownership of the serial port is properly freed to allow subsequent operations (or reattempts) to access the port. This PR closes the port if the connection fails when calling `get_esp`.

# This change fixes the following bug(s):
- If a call to `get_esp` results in `Failed to connect to ESP32: No serial data received.`, subsequent calls result in `Could not open /dev/cu.usbserial-1101, the port is busy or doesn't exist. ([Errno 35] Could not exclusively lock port /dev/cu.usbserial-1101: [Errno 35] Resource temporarily unavailable)` due to `get_esp` not properly closing the port on the first call.

# I have tested this change with the following hardware & software combinations:
NO TESTING

# I have run the esptool.py automated integration tests with this change and the above hardware:
NO TESTING
