### PR TITLE
fix: Close the data file after reading the data (ESPTOOL-1029)

### DIFF
--- a/espefuse/efuse/esp32/operations.py
+++ b/espefuse/efuse/esp32/operations.py
@@ -229,6 +229,7 @@ def burn_key(esp, efuses, args):
             raise esptool.FatalError("Unknown block name - %s" % (block_name))
         num_bytes = efuse.bit_len // 8
         data = datafile.read()
+        datafile.close()
         revers_msg = None
         if block_name in ("flash_encryption", "secure_boot_v1"):
             revers_msg = "\tReversing the byte order"

--- a/espefuse/efuse/esp32c2/operations.py
+++ b/espefuse/efuse/esp32c2/operations.py
@@ -207,7 +207,11 @@ def burn_key(esp, efuses, args, digest=None):
 
     print("Burn keys to blocks:")
     for datafile, keypurpose in zip(datafile_list, keypurpose_list):
-        data = datafile if isinstance(datafile, bytes) else datafile.read()
+        if isinstance(datafile, bytes):
+            data = datafile
+        else:
+            data = datafile.read()
+            datafile.close()
 
         if keypurpose == "XTS_AES_128_KEY_DERIVED_FROM_128_EFUSE_BITS":
             efuse = efuses["BLOCK_KEY0_LOW_128"]

--- a/espefuse/efuse/esp32c3/operations.py
+++ b/espefuse/efuse/esp32c3/operations.py
@@ -251,6 +251,7 @@ def burn_key(esp, efuses, args, digest=None):
 
         if digest is None:
             data = datafile.read()
+            datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32c5/operations.py
+++ b/espefuse/efuse/esp32c5/operations.py
@@ -248,6 +248,7 @@ def burn_key(esp, efuses, args, digest=None):
                     data = b"\x00" * 8 + data
             else:
                 data = datafile.read()
+                datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32c6/operations.py
+++ b/espefuse/efuse/esp32c6/operations.py
@@ -258,6 +258,7 @@ def burn_key(esp, efuses, args, digest=None):
 
         if digest is None:
             data = datafile.read()
+            datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32c61/operations.py
+++ b/espefuse/efuse/esp32c61/operations.py
@@ -315,6 +315,7 @@ def burn_key(esp, efuses, args, digest=None):
                     data = b"\x00" * 8 + data
             else:
                 data = datafile.read()
+                datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32h2/operations.py
+++ b/espefuse/efuse/esp32h2/operations.py
@@ -262,6 +262,7 @@ def burn_key(esp, efuses, args, digest=None):
                     data = b"\x00" * 8 + data
             else:
                 data = datafile.read()
+                datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32h21/operations.py
+++ b/espefuse/efuse/esp32h21/operations.py
@@ -246,6 +246,7 @@ def burn_key(esp, efuses, args, digest=None):
                     data = b"\x00" * 8 + data
             else:
                 data = datafile.read()
+                datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32h4/operations.py
+++ b/espefuse/efuse/esp32h4/operations.py
@@ -244,6 +244,7 @@ def burn_key(esp, efuses, args, digest=None):
                     data = b"\x00" * 8 + data
             else:
                 data = datafile.read()
+                datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32p4/operations.py
+++ b/espefuse/efuse/esp32p4/operations.py
@@ -315,6 +315,7 @@ def burn_key(esp, efuses, args, digest=None):
                     data = b"\x00" * 8 + data
             else:
                 data = datafile.read()
+                datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32s2/operations.py
+++ b/espefuse/efuse/esp32s2/operations.py
@@ -367,6 +367,7 @@ def burn_key(esp, efuses, args, digest=None):
 
         if digest is None:
             data = datafile.read()
+            datafile.close()
         else:
             data = datafile
 

--- a/espefuse/efuse/esp32s3/operations.py
+++ b/espefuse/efuse/esp32s3/operations.py
@@ -368,6 +368,7 @@ def burn_key(esp, efuses, args, digest=None):
 
         if digest is None:
             data = datafile.read()
+            datafile.close()
         else:
             data = datafile
 


### PR DESCRIPTION
<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections that don't apply, including the section header. -->

I'm building a custom flash data tool for my specific needs. The flasher takes the release zip, which is packaged with a custom python script. If the secure boot is enabled, this release will also contain the digest of the private key, which needs to be flashed.

Relevant steps of the flasher, for this fix, are the following:
- Flasher unzips the release into temporary directory
- Finds the digest file
- Invokes espefuse with key digest to burn it.
- Remove temporary dir 

# This change fixes the following bug(s):
<!-- If your change fixes any bugs, list them in this section.

Please include the issue URL or the # issue number here. -->

The first 3 operations are successful
```bash
espefuse.py v4.8.1
Connecting....
Detecting chip type... ESP32-S3

=== Run "burn_key" command ===
Sensitive data will be hidden (see --show-sensitive-info)
Burn keys to blocks:
 - BLOCK_KEY0 -> [?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ?? ??]
        The same value for BLOCK_KEY0 is already burned. Do not change the efuse.
        'KEY_PURPOSE_0' is already 'SECURE_BOOT_DIGEST0'.
        Disabling write to key block
        The same value for WR_DIS is already burned. Do not change the efuse.


Check all blocks for burn...
idx, BLOCK_NAME,          Conclusion
Nothing to burn, see messages above.
Successful
```

but when I want to delete the temporary directory, the operation fails with the following message:

```
[WinError 32] The process can not access the file because it is being used by another process: 'C:\\Users\\Me\\AppData\\Local\\Temp\\tmpvlylxsp5\\digest.bin'
```

I found out that if I close the opened key file, the following operation is successful. I added changes for all other chips, but these are **not tested** on my end.

# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.

If you did not perform any testing, write "NO TESTING" in this section. -->
I found this bug and tested the change (for **esp32s3)** with the following setup:
- Windows 11
- Hardware: https://github.com/rtek1000/YD-ESP32-23 (esp32s3)
- esptool v4.8.1
- Python script
```Python
import os
import shutil
import tempfile
import zipfile
from espefuse import main as espefuse_main


def main():

    # Configuration
    zip_file_path = (
        "C:\\Users\\Me\\Downloads\\test.zip"  # Change this to the actual path
    )
    baud_rate = 460800
    port = "COM6"
    block_idx = 0

    # Step 1: Extract ZIP to a temporary directory
    temp_dir = tempfile.mkdtemp()
    try:
        with zipfile.ZipFile(zip_file_path, "r") as zip_ref:
            zip_ref.extractall(temp_dir)

        # Step 2: Load digest.bin
        digest_file = os.path.join(temp_dir, "digest.bin")
        if not os.path.exists(digest_file):
            raise FileNotFoundError(
                f"Error: {digest_file} not found in extracted files."
            )

        # Step 3: Burn the secure boot public key digest
        espefuse_main(
            [
                "--do-not-confirm",
                "--chip",
                "auto",
                "--port",
                str(port),
                "--baud",
                str(baud_rate),
                "burn_key",
                f"BLOCK_KEY{block_idx}",
                digest_file,
                "SECURE_BOOT_DIGEST0",
            ]
        )
        print("Secure boot eFuse burned with public key digest.")

    finally:
        # Step 4: Cleanup - Remove the temporary directory
        shutil.rmtree(temp_dir)
        print("Temporary files removed.")


if __name__ == "__main__":
    sys.exit(main())

```

# I have run the esptool.py automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool.py with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. -->
NO_TESTING
