### PR TITLE
docs: improve esptool documentation for clarity and Espressif Manual of Style compliance

### DIFF
--- a/docs/en/esptool/basic-commands.rst
+++ b/docs/en/esptool/basic-commands.rst
@@ -8,45 +8,45 @@ Basic Commands
 Write Binary Data to Flash: ``write-flash``
 -------------------------------------------
 
-Binary data can be written to the ESP's flash chip via the serial ``write-flash`` command:
+Binary data can be written to the ESP device's flash chip using the ``write-flash`` command:
 
 ::
 
     esptool.py --port COM4 write-flash 0x1000 my_app-0x01000.bin
 
-Multiple flash addresses and file names can be given on the same command line:
+Multiple flash addresses and file names can be specified in a single command:
 
 ::
 
     esptool.py --port COM4 write-flash 0x00000 my_app.elf-0x00000.bin 0x40000 my_app.elf-0x40000.bin
 
-The ``--chip`` argument is optional when writing to flash, esptool will detect the type of chip when it connects to the serial port.
+The ``--chip`` argument is optional for writing to flash; esptool will detect the chip type automatically.
 
 The ``--port`` argument is documented under :ref:`serial-port`.
 
 .. only:: esp8266
 
     The next arguments to ``write-flash`` are one or more pairs of offset (address) and file name. When generating ESP8266 "version 1" images, the file names created by ``elf2image`` include the flash offsets as part of the file name.
-    For other types of images, consult your SDK documentation to determine the files to flash at which offsets.
+    For other image types, consult your SDK documentation for the correct files and offsets.
 
 .. only:: not esp8266
 
-    The next arguments to ``write-flash`` are one or more pairs of offset (address) and file name. Consult your SDK documentation to determine the files to flash at which offsets.
+    The next arguments to ``write-flash`` are one or more pairs of offset (address) and file name. Consult your SDK documentation for the correct files and offsets.
 
-Numeric values passed to write-flash (and other commands) can be specified either in hex (ie 0x1000), or in decimal (ie 4096).
+Numeric values for ``write-flash`` (and other commands) can be specified in hexadecimal (e.g., 0x1000) or decimal (e.g., 4096).
 
-See the :ref:`troubleshooting` section if the ``write-flash`` command is failing, or the flashed module fails to boot.
+See the :ref:`troubleshooting` section if the ``write-flash`` command fails or the flashed device does not boot.
 
 Setting Flash Mode and Size
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-You may also need to specify arguments for :ref:`flash mode and flash size <flash-modes>`, if you wish to override the defaults. For example:
+You may need to specify arguments for :ref:`flash mode and flash size <flash-modes>` to override defaults. For example:
 
 ::
 
     esptool.py --port /dev/ttyUSB0 write-flash --flash-mode qio --flash-size 32m 0x0 bootloader.bin 0x1000 my_app.bin
 
-Since esptool v2.0, these options are not often needed as the default is to keep the flash mode and size from the ``.bin`` image file. See the :ref:`flash-modes` section for more details.
+Since esptool v2.0, these options are rarely needed, as the default is to keep the flash mode and size from the ``.bin`` image file. See the :ref:`flash-modes` section for more details.
 
 Compression
 ^^^^^^^^^^^

--- a/docs/en/esptool/basic-options.rst
+++ b/docs/en/esptool/basic-options.rst
@@ -3,57 +3,51 @@
 Basic Options
 =============
 
-These are the basic/fundamental esptool options needed to define the communication with an ESP target. For advanced configuration options, see the :ref:`advanced-options` page.
+These are the basic esptool options required to define communication with an ESP target. For advanced configuration, see :ref:`advanced-options`.
 
-Esptool has global and command-specific options. Global options have to be specified after ``esptool.py``. They are used to configure the serial port, baud rate, and chip type.
-Command-specific options are specified after the command and are used to configure the command itself. For more information about commands and their options, see :ref:`commands` or see help in the command line.
+Esptool has both global and command-specific options. Global options must be specified after ``esptool.py`` and configure the serial port, baud rate, and chip type. Command-specific options are specified after the command and configure that command. For more information, see :ref:`commands` or use the command-line help.
 
 .. _chip-type:
 
 Chip Type: ``--chip``, ``-c``
 -----------------------------
 
-* The target chip type can be selected using the ``--chip``/ ``-c`` option, e.g. ``esptool.py --chip {IDF_TARGET_PATH_NAME} <command>``.
-* A default chip type can be specified by setting the ``ESPTOOL_CHIP`` environment variable.
-* If no ``-c`` option or ``ESPTOOL_CHIP`` value is specified, ``esptool.py`` automatically detects the chip type when connecting.
-* Binary image generation commands, such as :ref:`elf2image <elf-2-image>` or :ref:`merge-bin <merge-bin>`, require the chip type to be specified.
+* Select the target chip type using ``--chip`` or ``-c``, e.g., ``esptool.py --chip {IDF_TARGET_PATH_NAME} <command>``.
+* Set a default chip type with the ``ESPTOOL_CHIP`` environment variable.
+* If neither ``-c`` nor ``ESPTOOL_CHIP`` is specified, esptool.py automatically detects the chip type when connecting.
+* Some commands, such as :ref:`elf2image <elf-2-image>` or :ref:`merge-bin <merge-bin>`, require the chip type to be specified.
 
 .. _serial-port:
 
 Serial Port: ``--port``, ``-p``
 -------------------------------
 
-*  The serial port is selected using the ``-p`` option, like ``-p /dev/ttyUSB0`` (Linux and macOS) or ``-p COM1`` (Windows).
-*  A default serial port can be specified by setting the ``ESPTOOL_PORT`` environment variable.
-*  If no ``-p`` option or ``ESPTOOL_PORT`` value is specified, ``esptool.py`` will enumerate all connected serial ports and try each one until it finds an Espressif device connected.
+* Select the serial port using ``-p``, e.g., ``-p /dev/ttyUSB0`` (Linux/macOS) or ``-p COM1`` (Windows).
+* Set a default serial port with the ``ESPTOOL_PORT`` environment variable.
+* If neither ``-p`` nor ``ESPTOOL_PORT`` is specified, esptool.py enumerates all connected serial ports and tries each until it finds an Espressif device.
 
 .. note::
 
-    Windows and macOS may require drivers to be installed for a particular USB/serial adapter, before a serial port is available. Consult the documentation for your particular device.
-    On macOS, you can also consult `System Information <https://support.apple.com/en-us/HT203001>`__'s list of USB devices to identify the manufacturer or device ID when the adapter is plugged in.
-    On Windows, you can use `Windows Update or Device Manager <https://support.microsoft.com/en-us/help/15048/windows-7-update-driver-hardware-not-working-properly>`__ to find a driver.
+    Windows and macOS may require drivers for your USB/serial adapter. Consult your device documentation.
+    On macOS, use `System Information <https://support.apple.com/en-us/HT203001>`__ to identify the device. On Windows, use `Device Manager <https://support.microsoft.com/en-us/help/15048/windows-7-update-driver-hardware-not-working-properly>`__.
 
-If using Cygwin or WSL on Windows, you have to convert the Windows-style name into a Unix-style path (``COM1`` -> ``/dev/ttyS0``, and so on). (This is not necessary if using ESP-IDF with the supplied Windows MSYS2 environment,
-this environment uses a native Windows Python which accepts COM ports as-is.)
+If using Cygwin or WSL on Windows, convert the Windows-style name to a Unix-style path (``COM1`` → ``/dev/ttyS0``). This is not necessary if using ESP-IDF with the MSYS2 environment, which accepts COM ports as-is.
 
-In Linux, the current user may not have access to serial ports and a "Permission Denied" or "Port doesn't exist" errors may appear.
-On most Linux distributions, the solution is to add the user to the ``dialout`` group (check e.g. ``ls -l /dev/ttyUSB0`` to find the group) with a command like ``sudo usermod -a -G dialout $USER``.
-You can call ``su - $USER`` to enable read and write permissions for the serial port without having to log out and back in again.
-Check your Linux distribution's documentation for more information.
+On Linux, you may need to add your user to the ``dialout`` group to access serial ports (see ``ls -l /dev/ttyUSB0`` for the group). Use ``sudo usermod -a -G dialout $USER`` and ``su - $USER`` to enable permissions without logging out. Consult your distribution's documentation for details.
 
 Baud Rate: ``--baud``, ``-b``
 -----------------------------
 
-The default esptool baud rate is 115200bps. Different rates may be set using ``-b 921600`` (or another baud rate of your choice). A default baud rate can also be specified using the ``ESPTOOL_BAUD`` environment variable. This can speed up ``write-flash`` and ``read-flash`` operations.
+The default esptool baud rate is 115200 bps. Set a different rate with ``-b 921600`` (or another value). You can also set a default with the ``ESPTOOL_BAUD`` environment variable. Higher baud rates speed up ``write-flash`` and ``read-flash`` operations.
 
-The baud rate is limited to 115200 when esptool establishes the initial connection, higher speeds are only used for data transfers.
+The baud rate is limited to 115200 when esptool establishes the initial connection; higher speeds are used only for data transfers.
 
-Most hardware configurations will work with ``-b 230400``, some with ``-b 460800``, ``-b 921600`` and/or ``-b 1500000`` or higher.
+Most hardware works with ``-b 230400``; some support ``-b 460800``, ``-b 921600``, or ``-b 1500000`` or higher.
 
 .. only:: esp8266
 
-    If you have connectivity problems then you can also set baud rates below 115200. You can also choose 74880, which is the :ref:`usual baud rate used by the ESP8266 <serial-port-settings>` to output :ref:`boot-log-esp8266` information.
+    If you have connectivity problems, you can set baud rates below 115200. You can also choose 74880, which is the :ref:`usual baud rate used by the ESP8266 <serial-port-settings>` to output :ref:`boot-log-esp8266` information.
 
 .. only:: not esp8266
 
-    If you have connectivity problems then you can also set baud rates below 115200.
+    If you have connectivity problems, you can set baud rates below 115200.

--- a/docs/en/esptool/flasher-stub.rst
+++ b/docs/en/esptool/flasher-stub.rst
@@ -3,22 +3,22 @@
 Flasher Stub
 ============
 
-``esptool.py`` is a serial flasher utility. It communicates with the ROM bootloader in `Espressif SoCs <https://www.espressif.com/en/products/hardware/socs>`_ in order to load user applications or read chip data via serial port.
+``esptool.py`` is a serial flasher utility that communicates with the ROM bootloader in `Espressif SoCs <https://www.espressif.com/en/products/hardware/socs>`_ to load user applications or read chip data via the serial port.
 
-The ROM bootloader is burned into the ESP chip during manufacturing and cannot be updated. A new version is issued only when a new chip revision is released.
+The ROM bootloader is programmed into the ESP chip during manufacturing and cannot be updated. A new version is issued only with a new chip revision.
 
-``esptool.py`` works around the limitations imposed by a fixed ROM bootloader by implementing a flasher stub (also known as "stub loader" or just "stub"). It is a small application used as a temporary substitute or extension for the ROM.
+``esptool.py`` overcomes the limitations of a fixed ROM bootloader by implementing a flasher stub (also known as a "stub loader" or simply "stub"). This is a small application used as a temporary substitute or extension for the ROM bootloader.
 
-When ``esptool.py`` connects to a chip, it first uploads the flasher stub, which basically replaces the original bootloader. All following operations are then handled by the stub.
+When ``esptool.py`` connects to a chip, it first uploads the flasher stub, which temporarily replaces the original bootloader. All subsequent operations are then handled by the stub.
 
 Benefits
 --------
 
-The flasher stub behaves the same as the original bootloader, but uses more heavily optimized UART routines.
+The flasher stub behaves like the original bootloader but uses optimized UART routines for improved performance.
 
-The main benefit is improved performance of flashing and some other operations (like reading flash). Additionally, it also allows to work around any bugs in ROM bootloaders.
+The main benefits are faster flashing and other operations (such as reading flash), as well as the ability to work around bugs in ROM bootloaders.
 
 Disabling the Stub Loader
 -------------------------
 
-There might be cases where it is necessary to disable the stub loader (e.g. debugging). To do that, run ``esptool.py`` with the ``--no-stub`` argument. All operations will then be handled by the original ROM bootloader. See the related :ref:`advanced options page <disable_stub>`.
+In some cases, you may need to disable the stub loader (e.g., for debugging). To do so, run ``esptool.py`` with the ``--no-stub`` argument. All operations will then be handled by the original ROM bootloader. See the related :ref:`advanced options page <disable_stub>`.

--- a/docs/en/esptool/scripting.rst
+++ b/docs/en/esptool/scripting.rst
@@ -1,19 +1,19 @@
 .. _scripting:
 
 Embedding into Custom Scripts
-=============================
+============================
 
-``esptool.py`` can be easily integrated into Python applications or called from other Python scripts.
+``esptool.py`` can be integrated into Python applications or called from other Python scripts.
 
 Using Esptool as a Python Module
 --------------------------------
 
-The esptool module provides a comprehensive Python API for interacting with ESP chips programmatically. By leveraging the API, developers can automate tasks such as flashing firmware, reading device information, managing flash memory, or preparing and analyzing binary images. The API supports both high-level abstractions and low-level control.
+The esptool module provides a comprehensive Python API for interacting with ESP chips programmatically. Developers can automate tasks such as flashing firmware, reading device information, managing flash memory, or preparing and analyzing binary images. The API supports both high-level abstractions and low-level control.
 
 Using the Command-Line Interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The most straightforward and basic integration option is to pass arguments to ``esptool.main()``. This workaround allows you to pass exactly the same arguments as you would on the CLI:
+The simplest integration is to pass arguments to ``esptool.main()``. This allows you to use the same arguments as on the CLI:
 
 .. code-block:: python
 
@@ -26,18 +26,18 @@ The most straightforward and basic integration option is to pass arguments to ``
 Public API Reference
 ^^^^^^^^^^^^^^^^^^^^
 
-For more control and custom integration, esptool exposes a public API - a set of high-level functions that encapsulate common operations and simplify the interaction with the ESP chip. These functions are designed to be user-friendly and provide an intuitive way to work with the chip. The public API is the recommended way to interact with the chip programmatically.
+For more control, esptool exposes a public API—a set of high-level functions that encapsulate common operations and simplify interaction with the ESP chip. These functions are user-friendly and provide an intuitive way to work with the chip. The public API is the recommended way to interact programmatically.
 
 Basic Workflow:
 
-1. **Detect and Connect**: Use ``detect_chip()`` to automatically identify the connected ESP chip and establish a connection, or manually create and instantiate a specific ``ESPLoader`` object (e.g. ``ESP32ROM``) and establish a connection in two steps.
-2. **Run Stub Flasher (Optional)**: Upload and execute the :ref:`stub flasher <stub>` which provides enhanced functionality and speed.
-3. **Perform Operations**: Utilize the chip object's methods or public API command functions to interact with the device.
-4. **Reset and Cleanup**: Ensure proper reset and resource cleanup using context managers.
+1. **Detect and Connect**: Use ``detect_chip()`` to identify the connected ESP chip and establish a connection, or manually instantiate a specific ``ESPLoader`` object (e.g., ``ESP32ROM``) and connect in two steps.
+2. **Run Stub Flasher (Optional)**: Upload and execute the :ref:`stub flasher <stub>` for enhanced functionality and speed.
+3. **Perform Operations**: Use the chip object's methods or public API command functions to interact with the device.
+4. **Reset and Cleanup**: Use context managers to ensure proper reset and resource cleanup.
 
 ------------
 
-This example demonstrates writing two binary files using high-level commands:
+Example: Writing two binary files using high-level commands:
 
 .. code-block:: python
 
@@ -49,85 +49,84 @@ This example demonstrates writing two binary files using high-level commands:
 
     with detect_chip(PORT) as esp:
         esp = run_stub(esp)  # Skip this line to avoid running the stub flasher
-        attach_flash(esp)  # Attach the flash memory chip, required for flash operations
+        attach_flash(esp)  # Attach the flash memory chip
         with open(BOOTLOADER, "rb") as bl_file, open(FIRMWARE, "rb") as fw_file:
-            write_flash(esp, [(0, bl_file), (0x1000, fw_file)])  # Write the binary files
+            write_flash(esp, [(0, bl_file), (0x1000, fw_file)])  # Write the binaries
         reset_chip(esp, "hard-reset")  # Reset the chip
 
-- The ``esp`` object has to be replaced with the stub flasher object returned by ``run_stub(esp)`` when the stub flasher is activated. This step can be skipped if the stub flasher is not needed.
-- Running ``attach_flash(esp)`` is required for any flash-memory-related operations to work.
-- Using the ``esp`` object in a context manager ensures the port gets closed properly after the block is executed.
+- Replace the ``esp`` object with the stub flasher object returned by ``run_stub(esp)`` if the stub flasher is used. This step can be skipped if not needed.
+- ``attach_flash(esp)`` is required for flash-memory operations.
+- Using the ``esp`` object in a context manager ensures the port is closed properly after execution.
 
 ------------
 
-The following example demonstrates running a series of flash memory operations in one go:
+Example: Running a series of flash memory operations:
 
 .. code-block:: python
 
     from esptool.cmds import (
-    erase_flash,
-    attach_flash,
-    flash_id,
-    read_flash,
-    reset_chip,
-    run_stub,
-    verify_flash,
-    write_flash,
+        erase_flash,
+        attach_flash,
+        flash_id,
+        read_flash,
+        reset_chip,
+        run_stub,
+        verify_flash,
+        write_flash,
     )
-    from esptool.targets import ESP32ROM  # Import the target class, e.g. ESP8266ROM, ESP32S3ROM, etc.
+    from esptool.targets import ESP32ROM
 
     PORT = "/dev/ttyACM0"
     BOOTLOADER = "bootloader.bin"
     FIRMWARE = "firmware.bin"
 
     with ESP32ROM(PORT) as esp:
-        esp.connect()  # Connect to the ESP chip, needed when ESP32ROM is instantiated directly
+        esp.connect()  # Connect to the ESP chip
         esp = run_stub(esp)  # Run the stub loader (optional)
-        attach_flash(esp)  # Attach the flash memory chip, required for flash operations
-        flash_id(esp)  # Print information about the flash chip
-        erase_flash(esp)  # Erase the flash memory first
+        attach_flash(esp)  # Attach the flash memory chip
+        flash_id(esp)  # Print flash chip info
+        erase_flash(esp)  # Erase the flash memory
         with open(BOOTLOADER, "rb") as bl_file, open(FIRMWARE, "rb") as fw_file:
-            write_flash(esp, [(0, bl_file), (0x1000, fw_file)])  # Write the binary files
-            verify_flash(esp, [(0, bl_file), (0x1000, fw_file)])  # Verify the written data
-        read_flash(esp, 0x0, 0x2400, "output.bin")  # Read the flash memory into a file
+            write_flash(esp, [(0, bl_file), (0x1000, fw_file)])
+            verify_flash(esp, [(0, bl_file), (0x1000, fw_file)])
+        read_flash(esp, 0x0, 0x2400, "output.bin")  # Read flash memory
         reset_chip(esp, "hard-reset")  # Reset the chip
 
-- This example doesn't use ``detect_chip()``, but instantiates a ``ESP32ROM`` class directly. This is useful when you know the target chip in advance. In this scenario ``esp.connect()`` is required to establish a connection with the device.
-- Multiple operations can be chained together in a single context manager block.
+- This example instantiates a ``ESP32ROM`` class directly. Use ``esp.connect()`` to establish a connection.
+- Multiple operations can be chained in a single context manager block.
 
 ------------
 
-The Public API implements a custom ``ImageSource`` input type, which expands to ``str | bytes | IO[bytes]`` - a path to the firmware image file, an opened file-like object, or the image data as bytes.
+The Public API uses a custom ``ImageSource`` input type, which can be ``str``, ``bytes``, or ``IO[bytes]``—a path to the firmware image file, an opened file-like object, or the image data as bytes.
 
 As output, the API returns a ``bytes`` object representing the binary image or writes the image to a file if the ``output`` parameter is provided.
 
-The following example converts an ELF file to a flashable binary, prints the image information, and flashes the image. The example demonstrates three different ways to achieve the same result, showcasing the flexibility of the API:
+Example: Converting an ELF file to a flashable binary, printing image info, and flashing the image (three approaches):
 
 .. code-block:: python
 
     ELF = "firmware.elf"
 
-    # var 1 - Loading ELF from a file, not writing binary to a file
+    # 1. Load ELF from a file, do not write binary to a file
     bin_file = elf2image(ELF, "esp32c3")
     image_info(bin_file)
     with detect_chip(PORT) as esp:
         attach_flash(esp)
         write_flash(esp, [(0, bin_file)])
 
-    # var 2 - Loading ELF from an opened file object, not writing binary to a file
+    # 2. Load ELF from an opened file object
     with open(ELF, "rb") as elf_file, detect_chip(PORT) as esp:
         bin_file = elf2image(elf_file, "esp32c3")
         image_info(bin_file)
         attach_flash(esp)
         write_flash(esp, [(0, bin_file)])
 
-    # var 3 - Loading ELF from a file, writing binary to a file
+    # 3. Load ELF from a file, write binary to a file
     elf2image(ELF, "esp32c3", "image.bin")
     image_info("image.bin")
     with detect_chip(PORT) as esp:
         attach_flash(esp)
         write_flash(esp, [(0, "image.bin")])
-
 
 ------------
 

--- a/docs/en/esptool/serial-connection.rst
+++ b/docs/en/esptool/serial-connection.rst
@@ -3,9 +3,9 @@
 Serial Connection
 =================
 
-The ROM serial bootloader of Espressif chips uses a 3.3V UART serial connection. Many development boards make the serial connections for you onboard.
+The ROM serial bootloader of Espressif chips uses a 3.3V UART serial connection. Many development boards provide onboard serial connections.
 
-However, if you are wiring the chip yourself to a USB/Serial adapter or similar then the following connections must be made:
+If you are wiring the chip yourself to a USB/Serial adapter or similar, make the following connections:
 
 +---------------------+-------------------+
 | ESP Chip Pin        | Serial Port Pin   |
@@ -17,16 +17,16 @@ However, if you are wiring the chip yourself to a USB/Serial adapter or similar 
 | Ground              | Ground            |
 +---------------------+-------------------+
 
-Note that TX (transmit) on the ESP chip is connected to RX (receive) on the serial port connection, and vice versa.
+Note: TX (transmit) on the ESP chip connects to RX (receive) on the serial port, and vice versa.
 
-Do not connect the chip to 5V TTL serial adapters, and especially not to "standard" RS-232 adapters! 3.3V serial only!
+**Warning:** Do not connect the chip to 5V TTL serial adapters or standard RS-232 adapters! Use 3.3V serial only.
 
 .. _serial-port-settings:
 
 Serial Port Settings
 --------------------
 
-When communicating with the {IDF_TARGET_NAME} ROM serial bootloader, the following serial port settings are recommended:
+When communicating with the {IDF_TARGET_NAME} ROM serial bootloader, use the following serial port settings:
 
 +---------------------+-------------------+
 | Baud rate           | {IDF_TARGET_BAUD_RATE}            |
@@ -44,10 +44,10 @@ When communicating with the {IDF_TARGET_NAME} ROM serial bootloader, the followi
 
     .. note::
 
-        You might experience issues when using low baud rates on {IDF_TARGET_NAME}. If you encounter any problems when connecting, please use at least 115200 or higher.
+        You might experience issues when using low baud rates on {IDF_TARGET_NAME}. If you encounter problems, use at least 115200 or higher.
 
 .. only:: esp8266
 
-    .. note::
+.. note::
 
-        Baud rate {IDF_TARGET_BAUD_RATE} is what the {IDF_TARGET_NAME} bootloader uses. The apps on top of the Espressif SDK (e.g. Arduino sketch) talk at 115200 if not specified otherwise.
+    The baud rate {IDF_TARGET_BAUD_RATE} is used by the {IDF_TARGET_NAME} bootloader. Applications on top of the Espressif SDK (e.g., Arduino sketches) use 115200 unless specified otherwise.


### PR DESCRIPTION
This PR updates the esptool documentation for improved clarity, consistency, and adherence to the Espressif Manual of Style.\n\n- Improved instructions and terminology\n- Consistent formatting for options and commands\n- Enhanced notes and warnings\n- Minor grammar and style corrections\n\nFiles updated:\n- docs/en/esptool/basic-options.rst\n- docs/en/esptool/basic-commands.rst\n- docs/en/esptool/flasher-stub.rst\n- docs/en/esptool/serial-connection.rst\n- docs/en/esptool/scripting.rst\n\nPlease review and provide feedback.