### PR TITLE
fix(esptool): Allow ELF files without segments again (ESPTOOL-1132)

### DIFF
--- a/esptool/bin_image.py
+++ b/esptool/bin_image.py
@@ -1434,6 +1434,8 @@ class ELFFile:
                 )
 
     def _read_segments(self, f, segment_header_offs, segment_header_count, shstrndx):
+        if segment_header_count == 0:
+            return
         f.seek(segment_header_offs)
         len_bytes = segment_header_count * self.LEN_SEG_HEADER
         segment_header = f.read(len_bytes)


### PR DESCRIPTION
The program header table can describe zero or more segments. However, commit ca16d5f3 introduced checks in _read_segments() that will fail on a zero number of program header entries.

ELF files created by objcopy based on a binary file may not have any segments / program header table. The number of program header entries e_phnum in the ELF header is zero.

This was fine before commit ca16d5f3, but is currently broken and esptool will exit with this error:
`A fatal error occurred: No segment header found at offset 0000 in ELF file.`

This PR reinstates the possibility of having no such entries by simply returning early and skip these checks in _read_segments() if e_phnum is zero.

The change has no implication if the number of entries is non-zero.

# I have tested this change with the following hardware & software combinations:
Tested with ELF files created by objcopy that have no segments. esptool elf2image now successfully creates an image.

# I have run the esptool automated integration tests with this change and the above hardware:
NO_TESTING
