### PR TITLE
rich-click 1.9 fix (ESPTOOL-1180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 </div>
 <hr>
 
+## v5.0.3 (2025-09-)
+
+- Fix bug with rich-click 1.9 compatibility *(Daniel Reeves - bd9241c)*
+
 ## v5.0.2 (2025-07-30)
 
 ### 🐛 Bug Fixes

--- a/espefuse/cli_util.py
+++ b/espefuse/cli_util.py
@@ -220,7 +220,7 @@ class Group(EsptoolGroup):
             commands = init_commands(port=None, chip=ctx.obj["chip"], skip_connect=True)
             commands.add_cli_commands(self)
         elif len(used_cmds) == 0:
-            self.get_help(ctx)
+            print(self.get_help(ctx))
             ctx.exit()
 
         cmd_groups = self.repeat_read_commands(used_cmds, cmd_groups)

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -31,7 +31,7 @@ __all__ = [
     "write_mem",
 ]
 
-__version__ = "5.0.2"
+__version__ = "5.0.3"
 
 import os
 import shlex


### PR DESCRIPTION
Resolves regression in rich-click 1.9.0 https://github.com/ewels/rich-click/issues/253

# This change fixes the following bug(s):

- rich-click 1.9.0 regression

# I have tested this change with the following hardware & software combinations:

NO TESTING

# I have run the esptool automated integration tests with this change and the above hardware:

NO TESTING
