### PR TITLE
ci(github): Use new macos-15-intel runner for macOS builds

### DIFF
--- a/.github/workflows/build_esptool.yml
+++ b/.github/workflows/build_esptool.yml
@@ -15,7 +15,7 @@ jobs:
           - platform: linux-amd64
             runner: ubuntu-latest
           - platform: macos-amd64
-            runner: macos-13
+            runner: macos-15-intel
           - platform: macos-arm64
             runner: macos-latest
           - platform: linux-armv7


### PR DESCRIPTION
<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. -->

# This change fixes the following bug(s):
<!-- If your change fixes any bugs, list them in this section.

Please include the issue URL or the # issue number here. -->

# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.

If you did not perform any testing, write "NO TESTING" in this section. -->

# I have run the esptool automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. -->
