### PR TITLE
fix(esp32c5): fix boot failure after USB-Serial-JTAG download (ESPTOOL-1230)

### DIFF
--- a/esptool/targets/esp32c5.py
+++ b/esptool/targets/esp32c5.py
@@ -60,7 +60,7 @@ class ESP32C5ROM(ESP32C6ROM):
     PCR_SYSCLK_XTAL_FREQ_V = 0x7F << 24
     PCR_SYSCLK_XTAL_FREQ_S = 24
 
-    UARTDEV_BUF_NO = 0x4085f514  # Variable in ROM .bss which indicates the port in use
+    UARTDEV_BUF_NO = 0x4085F514  # Variable in ROM .bss which indicates the port in use
 
     FLASH_FREQUENCY = {
         "80m": 0xF,
@@ -143,9 +143,11 @@ class ESP32C5ROM(ESP32C6ROM):
 
     def hard_reset(self):
         # Debug output using trace
-        self.trace(f'get_uart_no(): {self.get_uart_no()}')
-        self.trace(f'UARTDEV_BUF_NO_USB_JTAG_SERIAL: {self.UARTDEV_BUF_NO_USB_JTAG_SERIAL}')
-        self.trace(f'uses_usb_jtag_serial(): {self.uses_usb_jtag_serial()}')
+        self.trace(f"get_uart_no(): {self.get_uart_no()}")
+        self.trace(
+            f"UARTDEV_BUF_NO_USB_JTAG_SERIAL: {self.UARTDEV_BUF_NO_USB_JTAG_SERIAL}"
+        )
+        self.trace(f"uses_usb_jtag_serial(): {self.uses_usb_jtag_serial()}")
         ESPLoader.hard_reset(self, self.uses_usb_jtag_serial())
 
     def change_baud(self, baud):


### PR DESCRIPTION
<!-- Fill in a description of the change here, at least 100 characters.
Make sure other people will be able to understand what your pull request is about.
Delete any sections which don't apply, including the section header. -->

This commit resolves an issue where ESP32-C5 would fail to boot properly after firmware download via USB-Serial-JTAG interface, resulting in error `rst:0x7 (TG0_WDT_HPSYS),boot:0x18 (SPI_FAST_FLASH_BOOT).`

# This change fixes the following bug(s):
<!-- If your change fixes any bugs, list them in this section.

Please include the issue URL or the # issue number here. -->


Using IDF command `idf.py flash monitor` download then restart `esp32-c5` through **USB-Serial-JTAG**, sometimes, the chip reboot in loop with

`"rst:0x7 (TG0_WDT_HPSYS),boot:0x18 (SPI_FAST_FLASH_BOOT)" ` 

The commit 1059ec7faff24ea1647c80963ef65abc515ef0fd try to fix this issue, But this fix did not fully work as intended.

I test with ESP32C5 ECO2 and ECO3, The `self.uses_usb_jtag_serial()` always return `176` when donwload through USB-Serial-JTAG, return `36` when using UART. which means the `self.uses_usb_jtag_serial()` is always `False` and the patch not work as normal



# I have tested this change with the following hardware & software combinations:
<!-- In this section, describe the hardware and software combinations with which you tested the PR change - operating system(s), development board name(s), ESP8266 and/or ESP32 series.
If you did not perform any testing, write "NO TESTING" in this section. -->

- [x] ESP32-C5 ECO2
- [x] ESP32-C5 ECO3
- [x] esptool v5.1.0

**I believe this fix needs to be backported to other branches that support esp32-c5.**


# I have run the esptool automated integration tests with this change and the above hardware:
<!-- In this section, post the results of running the automatic integration tests of esptool with this change and the above hardware.

Details here: https://docs.espressif.com/projects/esptool/en/latest/contributing.html#automated-integration-tests

If you did not perform any testing, write "NO TESTING" in this section. -->
