### PR TITLE
Add workaround to support CP2102C (ESPTOOL-1303)

### DIFF
--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -373,6 +373,9 @@ class ESPLoader:
     ESPRESSIF_VID = 0x303A
 
     USB_JTAG_SERIAL_PID = 0x1001
+    HARDWARE_FLOW_CONTROL_VID_PIDS = [
+        (0x10C4, 0xEA64),  # SiLabs CP2102C USB to UART Bridge Controller
+    ]
 
     # Chip IDs that are no longer supported by esptool
     UNSUPPORTED_CHIPS = {
@@ -812,18 +815,20 @@ class ESPLoader:
         if mode == "usb-reset" or self.get_usb_vid_pid()[1] == self.USB_JTAG_SERIAL_PID:
             return (USBJTAGSerialReset(self._port),)
 
+        flow_control = self.uses_hardware_flow_control()
+
         # USB-to-Serial bridge
         if os.name != "nt" and not self._port.name.startswith("rfc2217:"):
             return (
-                UnixTightReset(self._port, delay),
-                UnixTightReset(self._port, extra_delay),
-                ClassicReset(self._port, delay),
-                ClassicReset(self._port, extra_delay),
+                UnixTightReset(self._port, delay, flow_control),
+                UnixTightReset(self._port, extra_delay, flow_control),
+                ClassicReset(self._port, delay, flow_control),
+                ClassicReset(self._port, extra_delay, flow_control),
             )
 
         return (
-            ClassicReset(self._port, delay),
-            ClassicReset(self._port, extra_delay),
+            ClassicReset(self._port, delay, flow_control),
+            ClassicReset(self._port, extra_delay, flow_control),
         )
 
     def connect(
@@ -1241,6 +1246,14 @@ class ESPLoader:
         True if the host sees this port as Espressif USB-OTG (VID/PID match).
         """
         return self.get_usb_vid_pid() == (self.ESPRESSIF_VID, self.IMAGE_CHIP_ID)
+
+    def uses_hardware_flow_control(self):
+        """
+        True if this port uses hardware flow control that esptool needs to know
+        about for resetting. This is determined by checking if the USB PID matches
+        known PIDs with hardware flow control.
+        """
+        return self.get_usb_vid_pid() in self.HARDWARE_FLOW_CONTROL_VID_PIDS
 
     def get_usb_mode(self):
         """
@@ -2044,7 +2057,9 @@ class ESPLoader:
         if cfg_custom_hard_reset_sequence is not None:
             CustomReset(self._port, cfg_custom_hard_reset_sequence)()
         else:
-            HardReset(self._port, uses_usb)()
+            HardReset(
+                self._port, uses_usb, flow_control=self.uses_hardware_flow_control()
+            )()
 
     def soft_reset(self, stay_in_bootloader):
         if not self.IS_STUB:

--- a/esptool/reset.py
+++ b/esptool/reset.py
@@ -30,9 +30,10 @@ DEFAULT_RESET_DELAY = 0.05  # default time to wait before releasing boot pin aft
 class ResetStrategy:
     print_once = PrintOnce(log.warning)
 
-    def __init__(self, port, reset_delay=DEFAULT_RESET_DELAY):
+    def __init__(self, port, reset_delay=DEFAULT_RESET_DELAY, flow_control=False):
         self.port = port
         self.reset_delay = reset_delay
+        self.flow_control = flow_control
 
     def __call__(self):
         """
@@ -89,6 +90,17 @@ class ResetStrategy:
             status &= ~TIOCM_RTS
         fcntl.ioctl(self.port.fileno(), TIOCMSET, struct.pack("I", status))
 
+    def _setHUPCL(self, enabled):
+        if os.name == "nt" or not hasattr(termios, "HUPCL"):
+            return False
+        attrs = termios.tcgetattr(self.port.fileno())
+        if enabled:
+            attrs[2] |= termios.HUPCL
+        else:
+            attrs[2] &= ~termios.HUPCL
+        termios.tcsetattr(self.port.fileno(), termios.TCSANOW, attrs)
+        return True
+
 
 class ClassicReset(ResetStrategy):
     """
@@ -102,7 +114,11 @@ class ClassicReset(ResetStrategy):
         self._setDTR(True)  # IO0=LOW
         self._setRTS(False)  # EN=HIGH, chip out of reset
         time.sleep(self.reset_delay)
-        self._setDTR(False)  # IO0=HIGH, done
+        if not self.flow_control:
+            # We usually want to put IO0 back high here, but we can't do that with
+            # some hardware-flow control enabled adapters (like the CP2102C),
+            # as they will otherwise pull RTS low when receiving data from the ESP32.
+            self._setDTR(False)  # IO0=HIGH, done
 
 
 class UnixTightReset(ResetStrategy):
@@ -118,8 +134,12 @@ class UnixTightReset(ResetStrategy):
         time.sleep(0.1)
         self._setDTRandRTS(True, False)  # IO0=LOW & EN=HIGH, chip out of reset
         time.sleep(self.reset_delay)
-        self._setDTRandRTS(False, False)  # IO0=HIGH, done
-        self._setDTR(False)  # Needed in some environments to ensure IO0=HIGH
+        if not self.flow_control:
+            # We usually want to put IO0 back high here, but we can't do that with
+            # some hardware-flow control enabled adapters (like the CP2102C),
+            # as they will otherwise pull RTS low when receiving data from the ESP32.
+            self._setDTRandRTS(False, False)  # IO0=HIGH, done
+            self._setDTR(False)  # Needed in some environments to ensure IO0=HIGH
 
 
 class USBJTAGSerialReset(ResetStrategy):
@@ -149,21 +169,39 @@ class HardReset(ResetStrategy):
     Can be used to reset out of the bootloader or to restart a running app.
     """
 
-    def __init__(self, port, uses_usb=False):
-        super().__init__(port)
+    def __init__(self, port, uses_usb=False, flow_control=False):
+        super().__init__(port, flow_control=flow_control)
         self.uses_usb = uses_usb
 
     def reset(self):
-        self._setRTS(True)  # EN->LOW
-        if self.uses_usb:
-            # Give the chip some time to come out of reset,
-            # to be able to handle further DTR/RTS transitions
-            time.sleep(0.2)
-            self._setRTS(False)
-            time.sleep(0.2)
-        else:
+        if self.flow_control:
+            # Hardware flow control-enabled adapters (like the CP2102C) can pull
+            # the device back into reset when closing.
+            # Keep DTR asserted across close so RTS flow-control changes can't reset
+            # the chip during boot chatter.
+            has_hupcl = self._setHUPCL(False)
+            self._setDTR(False)  # IO0=HIGH
+            self._setRTS(True)  # EN->LOW
+            time.sleep(0.1)
+            self._setDTR(True)
             time.sleep(0.1)
             self._setRTS(False)
+            if not has_hupcl:
+                # Windows has no HUPCL equivalent. Release RTS first while
+                # DTR is still asserted, then release DTR to leave the reset
+                # circuit idle before close.
+                self._setDTR(False)
+        else:
+            self._setRTS(True)  # EN->LOW
+            if self.uses_usb:
+                # Give the chip some time to come out of reset,
+                # to be able to handle further DTR/RTS transitions
+                time.sleep(0.2)
+                self._setRTS(False)
+                time.sleep(0.2)
+            else:
+                time.sleep(0.1)
+                self._setRTS(False)
 
 
 class CustomReset(ResetStrategy):


### PR DESCRIPTION
The [CP2102C](https://www.silabs.com/interface/usb-bridges/driverless-usb-bridges) is a new USB-to-UART bridge chip by Silicon Labs. It is not to be confused with the CP2102N, which is an older and completely different chip.

The CP2102C is quite attractive due to its low price (only around 1€ at sufficiently large quantities, vs 2-3€ for chips like the CP2102N), and it is supported by the CDC ACM driver, but it has one major issue: It has hardware flow control enabled by default (see [errata sheet](https://www.silabs.com/documents/public/errata/cp2102c-errata.pdf)), and this cannot be disabled.

In practice, when using the CP2102C with an ESP32, this means two things:
* The CTS pin must be tied to GND so that the CP2102C transmits anything at all. This is easy to ensure in hardware.
* From what I can tell, the RTS pin is pulled low whenever the CP210C receives something on its RX port and DTR is high. From my understanding there is nothing the computer can do about it. This completely breaks the reset sequence required for the ESP32, but this pull requests adds a workaround for this in software.

### Problem description
This is what happens without this workaround:
<img width="815" height="221" alt="Screenshot From 2026-04-07 14-41-27" src="https://github.com/user-attachments/assets/59bfef69-27fe-4a92-836c-221b24608947" />


BOOT is low, CHIP_PU=EN=~RST goes high, ESP32 enters boot mode. The problem: Whenever the ESP32 sends something while DTR is high, RTS goes low, which means CHIP_PU goes low, so the ESP32 resets and we can never successfully flash anything.

With this workaround, we get this instead (as it should be):
<img width="815" height="221" alt="Screenshot From 2026-04-07 14-43-08" src="https://github.com/user-attachments/assets/aaf2fcab-7a90-4647-948a-2f05e118752e" />

The only change: We do not set DTR=HIGH at the end of the reset sequence, but just keep it low.

<img width="863" height="353" alt="Screenshot From 2026-04-07 14-22-11" src="https://github.com/user-attachments/assets/b0db48cb-a90f-4bdc-99b2-99f1438479eb" />
With the "standard" reset circuitry like in the picture above, this ensures that we can flash the firmware correctly.

I understand that this is quite an "ugly" fix and that something similar can also be achieved simply using a custom reset sequence. It might nevertheless make sense to include a fix like this in esptool, as more and more people might start running into this issue now that the CP2102C is getting more common.

### I have tested this change with the following hardware & software combinations:
ESP32-D0WD-V3, CP2102C

### I have run the esptool automated integration tests with this change and the above hardware:
NO TESTING