### PR TITLE
Extract `connect_esp` command for scripting purposes (ESPTOOL-1318)

### DIFF
--- a/docs/en/esptool/scripting.rst
+++ b/docs/en/esptool/scripting.rst
@@ -30,7 +30,7 @@ For more control and custom integration, esptool exposes a public API - a set of
 
 Basic Workflow:
 
-1. **Detect and Connect**: Use ``detect_chip()`` to automatically identify the connected ESP chip and establish a connection, or manually create and instantiate a specific ``ESPLoader`` object (e.g. ``ESP32ROM``) and establish a connection in two steps.
+1. **Detect and Connect**: Use ``connect_esp()`` for a single call that mirrors the CLI - auto-discover the serial port, auto-detect the chip, and retry failed connections. Alternatively, manually create and instantiate a specific ``ESPLoader`` object (e.g. ``ESP32ROM``) and establish a connection in two steps.
 2. **Run Stub Flasher (Optional)**: Upload and execute the :ref:`stub flasher <stub>` which provides enhanced functionality and speed.
 3. **Perform Operations**: Utilize the chip object's methods or public API command functions to interact with the device.
 4. **Reset and Cleanup**: Ensure proper reset and resource cleanup using context managers.
@@ -41,13 +41,12 @@ This example demonstrates writing two binary files using high-level commands:
 
 .. code-block:: python
 
-    from esptool.cmds import detect_chip, attach_flash, reset_chip, run_stub, write_flash
+    from esptool.cmds import connect_esp, attach_flash, reset_chip, run_stub, write_flash
 
-    PORT = "/dev/ttyACM0"
     BOOTLOADER = "bootloader.bin"
     FIRMWARE = "firmware.bin"
 
-    with detect_chip(PORT) as esp:
+    with connect_esp() as esp:  # Auto-discover the port and detect the chip
         esp = run_stub(esp)  # Skip this line to avoid running the stub flasher
         attach_flash(esp)  # Attach the flash memory chip, required for flash operations
         with open(BOOTLOADER, "rb") as bl_file, open(FIRMWARE, "rb") as fw_file:
@@ -57,6 +56,7 @@ This example demonstrates writing two binary files using high-level commands:
 - The ``esp`` object has to be replaced with the stub flasher object returned by ``run_stub(esp)`` when the stub flasher is activated. This step can be skipped if the stub flasher is not needed.
 - Running ``attach_flash(esp)`` is required for any flash-memory-related operations to work.
 - Using the ``esp`` object in a context manager ensures the port gets closed properly after the block is executed.
+- ``connect_esp()`` auto-discovers the serial port and detects the chip; pass ``port="/dev/ttyACM0"`` to target a specific port. It accepts the same connection options as the CLI (``before``, ``port_filter``, ``connect_attempts``, etc.), and you can call ``esp.change_baud()`` on the returned object to raise the transfer speed.
 
 ------------
 
@@ -92,7 +92,7 @@ The following example demonstrates running a series of flash memory operations i
         read_flash(esp, 0x0, 0x2400, "output.bin")  # Read the flash memory into a file
         reset_chip(esp, "hard-reset")  # Reset the chip
 
-- This example doesn't use ``detect_chip()``, but instantiates a ``ESP32ROM`` class directly. This is useful when you know the target chip in advance. In this scenario ``esp.connect()`` is required to establish a connection with the device.
+- This example doesn't use ``connect_esp()``, but instantiates a ``ESP32ROM`` class directly. This is useful when you know the target chip in advance. In this scenario ``esp.connect()`` is required to establish a connection with the device.
 - Multiple operations can be chained together in a single context manager block.
 
 ------------
@@ -110,12 +110,12 @@ The following example converts an ELF file to a flashable binary, prints the ima
     # var 1 - Loading ELF from a file, not writing binary to a file
     bin_file = elf2image(ELF, "esp32c3")
     image_info(bin_file)
-    with detect_chip(PORT) as esp:
+    with connect_esp() as esp:
         attach_flash(esp)
         write_flash(esp, [(0, bin_file)])
 
     # var 2 - Loading ELF from an opened file object, not writing binary to a file
-    with open(ELF, "rb") as elf_file, detect_chip(PORT) as esp:
+    with open(ELF, "rb") as elf_file, connect_esp() as esp:
         bin_file = elf2image(elf_file, "esp32c3")
         image_info(bin_file)
         attach_flash(esp)
@@ -124,7 +124,7 @@ The following example converts an ELF file to a flashable binary, prints the ima
     # var 3 - Loading ELF from a file, writing binary to a file
     elf2image(ELF, "esp32c3", "image.bin")
     image_info("image.bin")
-    with detect_chip(PORT) as esp:
+    with connect_esp() as esp:
         attach_flash(esp)
         write_flash(esp, [(0, "image.bin")])
 
@@ -135,6 +135,12 @@ The following example converts an ELF file to a flashable binary, prints the ima
 
 Chip Control Operations
 """""""""""""""""""""""
+
+.. autofunction:: esptool.cmds.connect_esp
+
+.. autofunction:: esptool.cmds.connect_with_retries
+
+.. autofunction:: esptool.cmds.connect_first_available
 
 .. autofunction:: esptool.cmds.detect_chip
 
@@ -237,7 +243,7 @@ For granular control and more configuration freedom, you can directly access the
 
 .. code-block:: python
 
-    from esptool.cmds import detect_chip
+    from esptool.cmds import connect_esp
 
     # The port of the connected ESP
     PORT = "/dev/ttyACM0"
@@ -249,7 +255,7 @@ For granular control and more configuration freedom, you can directly access the
     def progress_callback(percent):
         print(f"Wrote: {int(percent)}%")
 
-    with detect_chip(PORT) as esp:
+    with connect_esp(port=PORT) as esp:
         description = esp.get_chip_description()
         features = esp.get_chip_features()
         print(f"Detected ESP on port {PORT}: {description}")

--- a/espefuse/__init__.py
+++ b/espefuse/__init__.py
@@ -233,7 +233,7 @@ def main(argv: list[str] | None = None, esp: esptool.ESPLoader | None = None):
     e.g. "--port /dev/ttyUSB1" thus becomes ['--port', '/dev/ttyUSB1'].
 
     esp - Optional override of the connected device previously
-    returned by esptool.get_default_connected_device()
+    returned by esptool.connect_esp()
     """
     args = esptool.expand_file_arguments(argv or sys.argv[1:])
     try:

--- a/esptool/__init__.py
+++ b/esptool/__init__.py
@@ -5,6 +5,9 @@
 
 __all__ = [
     "chip_id",
+    "connect_esp",
+    "connect_first_available",
+    "connect_with_retries",
     "detect_chip",
     "dump_mem",
     "elf2image",
@@ -38,10 +41,8 @@ __version__ = "5.3.1"
 import os
 import shlex
 import sys
-import time
 import traceback
 import typing as t
-from itertools import chain, cycle, repeat
 
 import rich_click as click
 import serial
@@ -68,6 +69,9 @@ from esptool.cmds import (
     NAND_BLOCK_COUNT,
     attach_flash,
     chip_id,
+    connect_esp,
+    connect_first_available,
+    connect_with_retries,
     detect_chip,
     detect_flash_size,
     dump_bbm,
@@ -506,23 +510,6 @@ def prepare_esp_object(ctx):
             inst._smart_features = False
         log.set_verbosity("verbose")
 
-    log.stage()
-
-    if ctx.obj["before"] != "no-reset-no-sync":
-        initial_baud = min(
-            ESPLoader.ESP_ROM_BAUD, ctx.obj["baud"]
-        )  # don't sync faster than the default baud rate
-    else:
-        initial_baud = ctx.obj["baud"]
-
-    if ctx.obj["port"] is None:
-        try:
-            ser_list = get_port_names(**parse_port_filters(ctx.obj["port_filter"]))
-        except ValueError as exc:
-            raise FatalError(str(exc)) from exc
-        log.print(f"Found {len(ser_list)} serial ports...")
-    else:
-        ser_list = [ctx.obj["port"]]
     open_port_attempts = os.environ.get(
         "ESPTOOL_OPEN_PORT_ATTEMPTS", DEFAULT_OPEN_PORT_ATTEMPTS
     )
@@ -531,40 +518,29 @@ def prepare_esp_object(ctx):
     except ValueError:
         raise FatalError("Invalid value for ESPTOOL_OPEN_PORT_ATTEMPTS.")
 
+    if ctx.obj["before"] != "no-reset-no-sync":
+        initial_baud = min(
+            ESPLoader.ESP_ROM_BAUD, ctx.obj["baud"]
+        )  # don't sync faster than the default baud rate
+    else:
+        initial_baud = ctx.obj["baud"]
+
     esp = ctx.obj.get("esp", None)
     ctx.obj["external_esp"] = esp is not None
-    if open_port_attempts != 1:
-        if ctx.obj["port"] is None or ctx.obj["chip"] == "auto":
-            log.warn(
-                "The ESPTOOL_OPEN_PORT_ATTEMPTS (open_port_attempts) option "
-                "can only be used with --port and --chip arguments."
-            )
-        else:
-            esp = esp or connect_loop(
-                ctx.obj["port"],
-                initial_baud,
-                ctx.obj["chip"],
-                open_port_attempts,
-                ctx.obj["trace"],
-                ctx.obj["before"],
-            )
-    esp = esp or get_default_connected_device(
-        ser_list,
-        port=ctx.obj["port"],
-        connect_attempts=ctx.obj["connect_attempts"],
-        initial_baud=initial_baud,
-        chip=ctx.obj["chip"],
-        trace=ctx.obj["trace"],
-        before=ctx.obj["before"],
-    )
-
-    if esp is None:
-        raise FatalError(
-            "Could not connect to an Espressif device "
-            f"on any of the {len(ser_list)} available serial ports."
+    if not ctx.obj["external_esp"]:
+        log.stage()
+        esp = connect_esp(
+            port=ctx.obj["port"],
+            chip=ctx.obj["chip"],
+            initial_baud=initial_baud,
+            port_filter=ctx.obj["port_filter"],
+            before=ctx.obj["before"],
+            trace=ctx.obj["trace"],
+            connect_attempts=ctx.obj["connect_attempts"],
+            open_port_attempts=open_port_attempts,
         )
+        log.stage(finish=True)
 
-    log.stage(finish=True)
     log.print(f"Connected to {esp.CHIP_NAME} on {escape(str(esp._port.port))}:")
 
     # 2) Print the chip info
@@ -1258,8 +1234,7 @@ def main(argv: list[str] | None = None, esp: ESPLoader | None = None):
     need to be added as individual items to the list
     e.g. "-b 115200" thus becomes ['-b', '115200'].
 
-    esp - Optional override of the connected device previously
-    returned by get_default_connected_device()
+    esp - Optional override of the connected device object.
     """
     args = expand_file_arguments(argv or sys.argv[1:])
     try:
@@ -1292,78 +1267,18 @@ def expand_file_arguments(argv: list[str]) -> list[str]:
     return argv
 
 
-def connect_loop(
-    port: str,
-    initial_baud: int,
-    chip: str,
-    max_retries: int,
-    trace: bool = False,
-    before: str = "default-reset",
-):
-    chip_class = CHIP_DEFS[chip]
-    esp = None
-    log.print(f"Serial port {escape(str(port))}:")
-
-    first = True
-    ten_cycle = cycle(chain(repeat(False, 9), (True,)))
-    retry_loop = chain(
-        repeat(False, max_retries - 1), (True,) if max_retries else cycle((False,))
-    )
-
-    for last, every_tenth in zip(retry_loop, ten_cycle):
-        try:
-            esp = chip_class(port, initial_baud, trace)
-            if not first:
-                # break the retrying line
-                log.print("")
-            esp.connect(before)
-            return esp
-        except (FatalError, serial.serialutil.SerialException, OSError) as err:
-            if esp and esp._port:
-                esp._port.close()
-            esp = None
-            if first:
-                log.print(escape(str(err)))
-                log.print("Retrying failed connection", end="", flush=True)
-                first = False
-            if last:
-                raise err
-            if every_tenth:
-                # print a dot every second
-                log.print(".", end="", flush=True)
-            time.sleep(0.1)
+def connect_loop(*args, **kwargs):
+    """Deprecated alias for :func:`esptool.connect_with_retries`, kept for
+    backwards compatibility with downstream scripts. Prefer
+    :func:`esptool.connect_esp` for new code."""
+    return connect_with_retries(*args, **kwargs)
 
 
-def get_default_connected_device(
-    serial_list: list[str],
-    port: str,
-    connect_attempts: int,
-    initial_baud: int,
-    chip: str = "auto",
-    trace: bool = False,
-    before: str = "default-reset",
-):
-    _esp = None
-    for each_port in serial_list:
-        log.print(f"Serial port {escape(str(each_port))}:")
-        try:
-            if chip == "auto":
-                _esp = detect_chip(
-                    each_port, initial_baud, before, trace, connect_attempts
-                )
-            else:
-                chip_class = CHIP_DEFS[chip]
-                _esp = chip_class(each_port, initial_baud, trace)
-                _esp.connect(before, connect_attempts)
-            break
-        except (FatalError, OSError) as err:
-            if port is not None:
-                raise
-            log.err(f"{escape(str(each_port))} failed to connect: {escape(str(err))}")
-            if _esp and _esp._port:
-                _esp._port.close()
-            _esp = None
-    return _esp
+def get_default_connected_device(*args, **kwargs):
+    """Deprecated alias for :func:`esptool.connect_first_available`, kept for
+    backwards compatibility with downstream scripts. Prefer
+    :func:`esptool.connect_esp` for new code."""
+    return connect_first_available(*args, **kwargs)
 
 
 def _main():

--- a/esptool/cmds.py
+++ b/esptool/cmds.py
@@ -13,6 +13,8 @@ import time
 import zlib
 from typing import cast
 
+import serial
+from esp_pylib.serial_ports import get_port_names, parse_port_filters
 from intelhex import IntelHex
 from rich.markup import escape
 from serial import SerialException
@@ -26,6 +28,7 @@ from .bin_image import (
 )
 from .loader import (
     DEFAULT_CONNECT_ATTEMPTS,
+    DEFAULT_OPEN_PORT_ATTEMPTS,
     DEFAULT_TIMEOUT,
     ERASE_WRITE_TIMEOUT_PER_MB,
     NAND_BLOCK_SIZE,
@@ -107,6 +110,10 @@ FLASH_MODES = {
     "dio": 2,
     "dout": 3,
 }
+
+
+# Commands for obtaining an ESP object
+######################################
 
 
 def detect_chip(
@@ -214,6 +221,229 @@ def detect_chip(
         f"{err_msg} Failed to autodetect chip type."
         "\nProbably it is unsupported by this version of esptool."
     )
+
+
+def connect_with_retries(
+    port: str,
+    initial_baud: int,
+    chip: str,
+    max_retries: int,
+    trace: bool = False,
+    before: str = "default-reset",
+) -> ESPLoader:
+    """
+    Repeatedly attempt to open a single, known port and sync with the chip,
+    retrying on failure. ``connect_esp()`` is the recommended entry point;
+    use this lower-level helper when driving the retry loop directly.
+
+    Args:
+        port: The serial port to open.
+        initial_baud: The baud rate used when opening the port for the
+            initial sync (ROM bootloaders typically require 115200).
+        chip: Target chip name (e.g. ``"esp32"``, ``"esp32s3"``).
+            Must be a concrete chip, not ``"auto"``.
+        max_retries: Number of attempts before giving up. ``0`` retries
+            forever until successful.
+        trace: Enables or disables tracing for debugging purposes.
+        before: The chip reset method to perform before each attempt
+            (``"default-reset"``, ``"usb-reset"``,
+            ``"no-reset"``, ``"no-reset-no-sync"``).
+
+    Returns:
+        A connected ESPLoader instance for the requested chip.
+    """
+    chip_class = CHIP_DEFS[chip]
+    esp = None
+    log.print(f"Serial port {escape(str(port))}:")
+
+    first = True
+    ten_cycle = itertools.cycle(itertools.chain(itertools.repeat(False, 9), (True,)))
+    retry_loop = itertools.chain(
+        itertools.repeat(False, max_retries - 1),
+        (True,) if max_retries else itertools.cycle((False,)),
+    )
+
+    for last, every_tenth in zip(retry_loop, ten_cycle):
+        try:
+            esp = chip_class(port, initial_baud, trace)
+            if not first:
+                # break the retrying line
+                log.print("")
+            esp.connect(before)
+            return esp
+        except (FatalError, serial.serialutil.SerialException, OSError) as err:
+            if esp and esp._port:
+                esp._port.close()
+            esp = None
+            if first:
+                log.print(escape(str(err)))
+                log.print("Retrying failed connection", end="", flush=True)
+                first = False
+            if last:
+                raise err
+            if every_tenth:
+                # print a dot every second
+                log.print(".", end="", flush=True)
+            time.sleep(0.1)
+
+    raise AssertionError("unreachable: retry loop should return or re-raise")
+
+
+def connect_first_available(
+    serial_list: list[str],
+    port: str | None,
+    connect_attempts: int,
+    initial_baud: int,
+    chip: str = "auto",
+    trace: bool = False,
+    before: str = "default-reset",
+) -> ESPLoader | None:
+    """
+    Iterate ``serial_list`` and return the first port that connects
+    successfully. ``connect_esp()`` is the recommended entry point;
+    use this lower-level helper when driving port iteration directly.
+
+    Args:
+        serial_list: Candidate serial port devices to try.
+        port: Original user-supplied port, or ``None`` if auto-discovering.
+            When set, the first connection error is re-raised instead of
+            being swallowed to move on to the next candidate.
+        connect_attempts: Number of sync attempts per candidate port.
+        initial_baud: The baud rate used when opening each port for the
+            initial sync (ROM bootloaders typically require 115200).
+        chip: Target chip name, or ``"auto"`` to detect.
+        trace: Enables or disables tracing for debugging purposes.
+        before: The chip reset method to perform when connecting
+            (``"default-reset"``, ``"usb-reset"``,
+            ``"no-reset"``, ``"no-reset-no-sync"``).
+
+    Returns:
+        A connected ESPLoader instance for the first reachable port,
+        or ``None`` if no candidate could be connected.
+    """
+    esp = None
+    for each_port in serial_list:
+        log.print(f"Serial port {escape(str(each_port))}:")
+        try:
+            if chip == "auto":
+                esp = detect_chip(
+                    each_port, initial_baud, before, trace, connect_attempts
+                )
+            else:
+                chip_class = CHIP_DEFS[chip]
+                esp = chip_class(each_port, initial_baud, trace)
+                esp.connect(before, connect_attempts)
+            break
+        except (FatalError, OSError) as err:
+            if port is not None:
+                raise
+            log.err(f"{escape(str(each_port))} failed to connect: {escape(str(err))}")
+            if esp and esp._port:
+                esp._port.close()
+            esp = None
+    return esp
+
+
+def connect_esp(
+    port: str | None = None,
+    chip: str = "auto",
+    initial_baud: int = ESPLoader.ESP_ROM_BAUD,
+    port_filter: list[str] | None = None,
+    before: str = "default-reset",
+    trace: bool = False,
+    connect_attempts: int = DEFAULT_CONNECT_ATTEMPTS,
+    open_port_attempts: int = DEFAULT_OPEN_PORT_ATTEMPTS,
+) -> ESPLoader:
+    """
+    Connect to an Espressif device, mirroring how the esptool CLI
+    establishes a connection: auto-discover serial ports, auto-detect
+    the chip, and retry failed connections.
+
+    This is the recommended single-call entry point for scripts that want
+    the full CLI connection behavior (port discovery, chip detection, and
+    reset/sync retries) without reimplementing it around ``detect_chip()``.
+
+    Args:
+        port: Specific serial port device to use (e.g. ``"/dev/ttyACM0"``),
+            or ``None`` to auto-discover ports via ``port_filter``.
+        chip: Target chip name (e.g. ``"esp32"``, ``"esp32s3"``),
+            or ``"auto"`` to detect.
+        initial_baud: The baud rate the port is opened at for the initial
+            sync, **not** an operational rate. ROM bootloaders typically
+            require 115200 (the default); ``connect_esp()`` does not upgrade
+            to a faster rate on its own — call ``esp.change_baud()`` on the
+            returned object afterward if you need a faster transfer speed.
+        port_filter: Filters applied when auto-discovering ports (ignored
+            when ``port`` is given), each entry of the form ``"vid=NUMBER"``,
+            ``"pid=NUMBER"``, ``"name=SUBSTRING"`` or ``"serial=SUBSTRING"``.
+        before: The chip reset method to perform when connecting
+            (``"default-reset"``, ``"usb-reset"``,
+            ``"no-reset"``, ``"no-reset-no-sync"``).
+        trace: Enables or disables tracing for debugging purposes.
+        connect_attempts: Number of sync attempts per candidate port
+            before moving on (or giving up if ``port`` was set).
+        open_port_attempts: Number of times to retry opening ``port``
+            if it fails to open. ``1`` (default) means try once; only
+            meaningful when both ``port`` and a concrete ``chip`` are
+            specified.
+
+    Returns:
+        A connected ``ESPLoader`` instance for the detected or requested chip.
+
+    Raises:
+        FatalError: If no Espressif device could be reached on any of the
+            candidate serial ports.
+
+    Example:
+        ::
+
+            from esptool.cmds import connect_esp, attach_flash, run_stub
+
+            # Auto-discover the port and auto-detect the chip
+            with connect_esp() as esp:
+                esp = run_stub(esp)  # Optional: upload the stub flasher
+                esp.change_baud(921600)  # Upgrade to a faster operational rate
+                attach_flash(esp)
+                ...
+    """
+    if port is None:
+        try:
+            ser_list = get_port_names(**parse_port_filters(tuple(port_filter or [])))
+        except ValueError as exc:
+            raise FatalError(str(exc)) from exc
+        log.print(f"Found {len(ser_list)} serial ports...")
+    else:
+        ser_list = [port]
+
+    esp = None
+    if open_port_attempts != 1:
+        if port is None or chip == "auto":
+            log.warn(
+                "The ESPTOOL_OPEN_PORT_ATTEMPTS (open_port_attempts) option "
+                "can only be used with --port and --chip arguments."
+            )
+        else:
+            esp = connect_with_retries(
+                port, initial_baud, chip, open_port_attempts, trace, before
+            )
+
+    esp = esp or connect_first_available(
+        ser_list,
+        port=port,
+        connect_attempts=connect_attempts,
+        initial_baud=initial_baud,
+        chip=chip,
+        trace=trace,
+        before=before,
+    )
+
+    if esp is None:
+        raise FatalError(
+            "Could not connect to an Espressif device "
+            f"on any of the {len(ser_list)} available serial ports."
+        )
+
+    return esp
 
 
 # Commands that require an ESP object

--- a/esptool/loader.py
+++ b/esptool/loader.py
@@ -504,6 +504,10 @@ class ESPLoader:
                 f"Failed to set baud rate {baud}. The driver may not support this rate."
             )
 
+    def get_baud(self):
+        """Return the current serial port baud rate."""
+        return self._port.baudrate
+
     def read(self):
         """Read a SLIP packet from the serial port"""
         try:

--- a/test/test_esptool.py
+++ b/test/test_esptool.py
@@ -53,7 +53,6 @@ try:
     from esptool import FatalError
     from esptool.cmds import (
         attach_flash,
-        detect_chip,
         erase_flash,
         flash_id,
         image_info,
@@ -1291,8 +1290,11 @@ class TestSecurityInfo(EsptoolTestCase):
             assert "Key Purposes" in res
         if arg_chip != "esp32s2":
             try:
-                esp = esptool.get_default_connected_device(
-                    [arg_port], arg_port, 10, 115200, arg_chip
+                esp = esptool.connect_esp(
+                    port=arg_port,
+                    chip=arg_chip,
+                    initial_baud=115200,
+                    connect_attempts=10,
                 )
                 assert f"Chip ID: {esp.IMAGE_CHIP_ID}" in res
                 assert "API Version" in res
@@ -2039,8 +2041,11 @@ class TestReadWriteMemory(EsptoolTestCase):
 
     def test_read_write_memory_rom(self):
         try:
-            esp = esptool.get_default_connected_device(
-                [arg_port], arg_port, 10, 115200, arg_chip
+            esp = esptool.connect_esp(
+                port=arg_port,
+                chip=arg_chip,
+                initial_baud=115200,
+                connect_attempts=10,
             )
             self._test_read_write(esp)
         finally:
@@ -2048,8 +2053,11 @@ class TestReadWriteMemory(EsptoolTestCase):
 
     def test_read_write_memory_stub(self):
         try:
-            esp = esptool.get_default_connected_device(
-                [arg_port], arg_port, 10, 115200, arg_chip
+            esp = esptool.connect_esp(
+                port=arg_port,
+                chip=arg_chip,
+                initial_baud=115200,
+                connect_attempts=10,
             )
             esp = esp.run_stub()
             self._test_read_write(esp)
@@ -2071,8 +2079,11 @@ class TestReadWriteMemory(EsptoolTestCase):
 
     def test_read_chip_description(self):
         try:
-            esp = esptool.get_default_connected_device(
-                [arg_port], arg_port, 10, 115200, arg_chip
+            esp = esptool.connect_esp(
+                port=arg_port,
+                chip=arg_chip,
+                initial_baud=115200,
+                connect_attempts=10,
             )
             chip = esp.get_chip_description()
             assert "unknown" not in chip.lower()
@@ -2081,8 +2092,11 @@ class TestReadWriteMemory(EsptoolTestCase):
 
     def test_read_get_chip_features(self):
         try:
-            esp = esptool.get_default_connected_device(
-                [arg_port], arg_port, 10, 115200, arg_chip
+            esp = esptool.connect_esp(
+                port=arg_port,
+                chip=arg_chip,
+                initial_baud=115200,
+                connect_attempts=10,
             )
 
             if hasattr(esp, "get_flash_cap") and esp.get_flash_cap() == 0:
@@ -2302,8 +2316,7 @@ class TestESPObjectOperations(EsptoolTestCase):
     @pytest.mark.quick_test
     @capture_stdout
     def test_stub_run(self, fake_out):
-        with esptool.CHIP_DEFS[arg_chip](port=arg_port) as esp:
-            esp.connect()
+        with esptool.connect_esp(port=arg_port, chip=arg_chip) as esp:
             esp = esp.run_stub()
             read_mac(esp)
             reset_chip(esp, "hard-reset")
@@ -2313,7 +2326,7 @@ class TestESPObjectOperations(EsptoolTestCase):
 
     @capture_stdout
     def test_flash_operations(self, fake_out):
-        with detect_chip(port=arg_port) as esp:  # Test with chip autodetection
+        with esptool.connect_esp(port=arg_port) as esp:  # Test with chip autodetection
             esp = esp.run_stub()
             try:
                 attach_flash(esp)
@@ -2378,7 +2391,7 @@ class TestESPObjectOperations(EsptoolTestCase):
 
             addr = 0x10000
             # Use API directly to flash old file first
-            with detect_chip(port=arg_port) as esp:
+            with esptool.connect_esp(port=arg_port) as esp:
                 esp = esp.run_stub()
                 try:
                     attach_flash(esp)
@@ -2404,7 +2417,7 @@ class TestESPObjectOperations(EsptoolTestCase):
                     reset_chip(esp, "hard-reset")
 
             # Test with no_diff_verify=True
-            with detect_chip(port=arg_port) as esp:
+            with esptool.connect_esp(port=arg_port) as esp:
                 esp = esp.run_stub()
                 try:
                     attach_flash(esp)
@@ -2432,6 +2445,22 @@ class TestESPObjectOperations(EsptoolTestCase):
             os.unlink(old_bin.name)
             os.unlink(new_bin.name)
 
+    @pytest.mark.quick_test
+    @capture_stdout
+    def test_connect_esp_change_baud(self, fake_out):
+        # connect_esp() opens the port at the ROM sync rate; the documented
+        # follow-up is to run the stub and then esp.change_baud() to raise the
+        # operational rate (ESP8266 ROM can't change baud, only the stub can).
+        with esptool.connect_esp(port=arg_port, chip=arg_chip) as esp:
+            esp = esp.run_stub()
+            esp.change_baud(460800)
+            assert esp.get_baud() == 460800
+            read_mac(esp)  # Confirm the link still works at the new rate
+            reset_chip(esp, "hard-reset")
+        output = fake_out.getvalue()
+        assert "Changing baud rate to 460800" in output
+        assert "MAC:" in output
+
 
 @pytest.mark.host_test
 class TestOldScripts:
@@ -2458,6 +2487,26 @@ class TestOldScripts:
         output = self._run_old_script_help("esp_rfc2217_server.py")
         assert "esp_rfc2217_server.py" in output
         assert "DEPRECATED" in output
+
+
+@pytest.mark.host_test
+class TestDeprecatedAliases:
+    """The deprecated aliases must keep forwarding to their replacements so
+    downstream scripts don't break (no hardware required)."""
+
+    def test_connect_loop_forwards_to_connect_with_retries(self):
+        sentinel = object()
+        with patch("esptool.connect_with_retries", return_value=sentinel) as mocked:
+            result = esptool.connect_loop("port", 1, "esp32", 2, trace=True)
+        mocked.assert_called_once_with("port", 1, "esp32", 2, trace=True)
+        assert result is sentinel
+
+    def test_get_default_connected_device_forwards_to_connect_first_available(self):
+        sentinel = object()
+        with patch("esptool.connect_first_available", return_value=sentinel) as mocked:
+            result = esptool.get_default_connected_device(["port"], None, 2, 115200)
+        mocked.assert_called_once_with(["port"], None, 2, 115200)
+        assert result is sentinel
 
 
 @pytest.mark.host_test


### PR DESCRIPTION
This change extracts the connection logic in the `esptool` (CLI/Click) specific `prepare_esp_object(ctx)` function into a reusable `connect_esp` command.

This greatly simplifies the creation of user facing scripts vs. `detect_chip(PORT)`.

-----

**Before**
To achieve "auto" connections:

```python
def get_esp(port: str | None, baud: int) -> ESPLoader:
    esp: ESPLoader | None = None
    if port:
        esp = detect_chip(port, baud=baud)
    else:
        ports = get_port_list()
        for port in ports:
            try:
                print(f"Serial port {port} (baud={baud})")
                esp = detect_chip(port, baud=baud)
                break
            except RuntimeError:
                pass
    if not esp:
        raise RuntimeError("No ESP found")
    return run_stub(esp)
```

... and no support for `open_port_attempts` and others
<details>
<summary>...and missing dependencies</summary>

```python
# These are not exported from `esptool` so have to be copied
def get_port_list() -> list[str]:
    """Get the list of serial ports names with optional filters.

    For backwards compatibility, this function returns a list of port names.
    """
    return [port.device for port in _get_port_list()]


def _get_port_list() -> list[ListPortInfo]:
    ports = []
    for port in list_ports.comports():
        if sys.platform == "darwin" and port.device.endswith(
            ("Bluetooth-Incoming-Port", "wlan-debug", "cu.debug-console")
        ):
            continue
        ports.append(port)

    # Constants for sorting optimization
    ESPRESSIF_VID = 0x303A
    LINUX_DEVICE_PATTERNS = ("ttyUSB", "ttyACM")
    MACOS_DEVICE_PATTERNS = ("usbserial", "usbmodem")

    def _port_sort_key_linux(port_info: ListPortInfo) -> tuple[int, str]:
        if port_info.vid == ESPRESSIF_VID:
            return (3, port_info.device)

        if any(pattern in port_info.device for pattern in LINUX_DEVICE_PATTERNS):
            return (2, port_info.device)

        return (1, port_info.device)

    def _port_sort_key_macos(port_info: ListPortInfo) -> tuple[int, str]:
        if port_info.vid == ESPRESSIF_VID:
            return (3, port_info.device)

        if any(pattern in port_info.device for pattern in MACOS_DEVICE_PATTERNS):
            return (2, port_info.device)

        return (1, port_info.device)

    def _port_sort_key_windows(port_info: ListPortInfo) -> tuple[int, str]:
        if port_info.vid == ESPRESSIF_VID:
            return (2, port_info.device)

        return (1, port_info.device)

    if sys.platform == "win32":
        key_func = _port_sort_key_windows
    elif sys.platform == "darwin":
        key_func = _port_sort_key_macos
    else:
        key_func = _port_sort_key_linux

    sorted_port_info = sorted(ports, key=key_func)
    return sorted_port_info
```

</details>

----

**After**
```python
def get_esp(port: str | None, baud: int) -> ESPLoader:
    esp = connect_esp(port)
    esp.change_baud(baud)
    return run_stub(esp)
```

----

### I have tested this change with the following hardware & software combinations:
ESP32-S3, custom board

Tests added for command.

### I have run the esptool automated integration tests with this change and the above hardware:
<details>
<summary><code>pytest test_esptool.py --port /dev/cu.usbmodem101 --chip esp32s3 --baud 115200</code></summary>

```
============================================================================================================================ test session starts =============================================================================================================================
platform darwin -- Python 3.13.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /REDACTED/esptool
configfile: pyproject.toml
plugins: rerunfailures-16.3
collected 121 items

test_esptool.py sssss.s......sss...................s.s..ss.s............s.s.....ss..............s...sssssss.....FF...s...ssss............ [100%]

======================================================= FAILURES =======================================================
____________________________________ TestVirtualPort.test_auto_detect_virtual_port _____________________________________

self = <test_esptool.TestVirtualPort object at 0x106e84410>

    def test_auto_detect_virtual_port(self):
        with ESPRFC2217Server() as server:
>           output = self.run_esptool(
                "chip-id",
                chip="auto",
                port=f"rfc2217://127.0.0.1:{str(server.port)}?ign_set_control",
            )

test_esptool.py:1952:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_esptool.py:262: in run_esptool
    output = run_esptool_process(full_cmd)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test_esptool.py:208: in run_esptool_process
    raise e
test_esptool.py:200: in run_esptool_process
    output = subprocess.check_output(
/opt/homebrew/Cellar/python@3.13/3.13.13_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py:472: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

input = None, capture_output = False, timeout = None, check = True
popenargs = (['/REDACTED/esptool/.venv/bin/python3.13', '-m', 'esptool', '--port', 'rfc2217://127.0.0.1:62352?ign_set_control', '--baud', ...],)
kwargs = {'cwd': '/REDACTED/esptool/test', 'stderr': -2, 'stdout': -1}
process = <Popen: returncode: 1 args: ['/REDACTED/esptool/.venv/bin/pyth...>
stdout = b'esptool v5.2.0\nSerial port rfc2217://127.0.0.1:62352?ign_set_control:\nConnecting...\nDevice VID/PID identification.../ serial ports.\n\nDevice VID/PID identification is only supported on COM and /dev/ serial ports.\n.................\n'
stderr = None, retcode = 1

    def run(*popenargs,
            input=None, capture_output=False, timeout=None, check=False, **kwargs):
        """Run command with arguments and return a CompletedProcess instance.

        The returned instance will have attributes args, returncode, stdout and
        stderr. By default, stdout and stderr are not captured, and those attributes
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them,
        or pass capture_output=True to capture both.

        If check is True and the exit code was non-zero, it raises a
        CalledProcessError. The CalledProcessError object will have the return code
        in the returncode attribute, and output & stderr attributes if those streams
        were captured.

        If timeout (seconds) is given and the process takes too long,
         a TimeoutExpired exception will be raised.

        There is an optional argument "input", allowing you to
        pass bytes or a string to the subprocess's stdin.  If you use this argument
        you may not also use the Popen constructor's "stdin" argument, as
        it will be used internally.

        By default, all communication is in bytes, and therefore any "input" should
        be bytes, and the stdout and stderr will be bytes. If in text mode, any
        "input" should be a string, and stdout and stderr will be strings decoded
        according to locale encoding, or by "encoding" if set. Text mode is
        triggered by setting any of text, encoding, errors or universal_newlines.

        The other arguments are the same as for the Popen constructor.
        """
        if input is not None:
            if kwargs.get('stdin') is not None:
                raise ValueError('stdin and input arguments may not both be used.')
            kwargs['stdin'] = PIPE

        if capture_output:
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
                raise ValueError('stdout and stderr arguments may not be used '
                                 'with capture_output.')
            kwargs['stdout'] = PIPE
            kwargs['stderr'] = PIPE

        with Popen(*popenargs, **kwargs) as process:
            try:
                stdout, stderr = process.communicate(input, timeout=timeout)
            except TimeoutExpired as exc:
                process.kill()
                if _mswindows:
                    # Windows accumulates the output in a single blocking
                    # read() call run on child threads, with the timeout
                    # being done in a join() on those threads.  communicate()
                    # _after_ kill() is required to collect that and add it
                    # to the exception.
                    exc.stdout, exc.stderr = process.communicate()
                else:
                    # POSIX _communicate already populated the output so
                    # far into the TimeoutExpired exception.
                    process.wait()
                raise
            except:  # Including KeyboardInterrupt, communicate handled that.
                process.kill()
                # We don't call process.wait() as .__exit__ does that for us.
                raise
            retcode = process.poll()
            if check and retcode:
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['/REDACTED/esptool/.venv/bin/python3.13', '-m', 'esptool', '--port', 'rfc2217://127.0.0.1:62352?ign_set_control', '--baud', '115200', 'chip-id']' returned non-zero exit status 1.

/opt/homebrew/Cellar/python@3.13/3.13.13_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py:577: CalledProcessError
------------------------------------------------- Captured stdout call -------------------------------------------------
Server started successfully.

Running the "chip-id" command...
Executing /REDACTED/esptool/.venv/bin/python3.13 -m esptool --port rfc2217://127.0.0.1:62352?ign_set_control --baud 115200 chip-id...
esptool v5.2.0
Serial port rfc2217://127.0.0.1:62352?ign_set_control:
Connecting...
Device VID/PID identification is only supported on COM and /dev/ serial ports.

Device VID/PID identification is only supported on COM and /dev/ serial ports.
.................

__________________________________ TestVirtualPort.test_highspeed_flash_virtual_port ___________________________________

self = <test_esptool.TestVirtualPort object at 0x106e84550>

    def test_highspeed_flash_virtual_port(self):
        with ESPRFC2217Server() as server:
            rfc2217_port = f"rfc2217://127.0.0.1:{str(server.port)}?ign_set_control"
>           self.run_esptool(
                "write-flash 0x0 images/fifty_kb.bin",
                baud=921600,
                port=rfc2217_port,
            )

test_esptool.py:1962:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_esptool.py:262: in run_esptool
    output = run_esptool_process(full_cmd)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test_esptool.py:208: in run_esptool_process
    raise e
test_esptool.py:200: in run_esptool_process
    output = subprocess.check_output(
/opt/homebrew/Cellar/python@3.13/3.13.13_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py:472: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

input = None, capture_output = False, timeout = None, check = True
popenargs = (['/REDACTED/esptool/.venv/bin/python3.13', '-m', 'esptool', '--chip', 'esp32s3', '--port', ...],)
kwargs = {'cwd': '/REDACTED/esptool/test', 'stderr': -2, 'stdout': -1}
process = <Popen: returncode: 1 args: ['/REDACTED/esptool/.venv/bin/pyth...>
stdout = b'esptool v5.2.0\nSerial port rfc2217://127.0.0.1:62474?ign_set_control:\nConnecting...\nDevice VID/PID identification...elf._socket.sendall(data)\n    ~~~~~~~~~~~~~~~~~~~~^^^^^^\nConnectionResetError: [Errno 54] Connection reset by peer\n'
stderr = None, retcode = 1

    def run(*popenargs,
            input=None, capture_output=False, timeout=None, check=False, **kwargs):
        """Run command with arguments and return a CompletedProcess instance.

        The returned instance will have attributes args, returncode, stdout and
        stderr. By default, stdout and stderr are not captured, and those attributes
        will be None. Pass stdout=PIPE and/or stderr=PIPE in order to capture them,
        or pass capture_output=True to capture both.

        If check is True and the exit code was non-zero, it raises a
        CalledProcessError. The CalledProcessError object will have the return code
        in the returncode attribute, and output & stderr attributes if those streams
        were captured.

        If timeout (seconds) is given and the process takes too long,
         a TimeoutExpired exception will be raised.

        There is an optional argument "input", allowing you to
        pass bytes or a string to the subprocess's stdin.  If you use this argument
        you may not also use the Popen constructor's "stdin" argument, as
        it will be used internally.

        By default, all communication is in bytes, and therefore any "input" should
        be bytes, and the stdout and stderr will be bytes. If in text mode, any
        "input" should be a string, and stdout and stderr will be strings decoded
        according to locale encoding, or by "encoding" if set. Text mode is
        triggered by setting any of text, encoding, errors or universal_newlines.

        The other arguments are the same as for the Popen constructor.
        """
        if input is not None:
            if kwargs.get('stdin') is not None:
                raise ValueError('stdin and input arguments may not both be used.')
            kwargs['stdin'] = PIPE

        if capture_output:
            if kwargs.get('stdout') is not None or kwargs.get('stderr') is not None:
                raise ValueError('stdout and stderr arguments may not be used '
                                 'with capture_output.')
            kwargs['stdout'] = PIPE
            kwargs['stderr'] = PIPE

        with Popen(*popenargs, **kwargs) as process:
            try:
                stdout, stderr = process.communicate(input, timeout=timeout)
            except TimeoutExpired as exc:
                process.kill()
                if _mswindows:
                    # Windows accumulates the output in a single blocking
                    # read() call run on child threads, with the timeout
                    # being done in a join() on those threads.  communicate()
                    # _after_ kill() is required to collect that and add it
                    # to the exception.
                    exc.stdout, exc.stderr = process.communicate()
                else:
                    # POSIX _communicate already populated the output so
                    # far into the TimeoutExpired exception.
                    process.wait()
                raise
            except:  # Including KeyboardInterrupt, communicate handled that.
                process.kill()
                # We don't call process.wait() as .__exit__ does that for us.
                raise
            retcode = process.poll()
            if check and retcode:
>               raise CalledProcessError(retcode, process.args,
                                         output=stdout, stderr=stderr)
E               subprocess.CalledProcessError: Command '['/REDACTED/esptool/.venv/bin/python3.13', '-m', 'esptool', '--chip', 'esp32s3', '--port', 'rfc2217://127.0.0.1:62474?ign_set_control', '--baud', '921600', 'write-flash', '0x0', 'images/fifty_kb.bin']' returned non-zero exit status 1.

/opt/homebrew/Cellar/python@3.13/3.13.13_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py:577: CalledProcessError
------------------------------------------------- Captured stdout call -------------------------------------------------
Server started successfully.

Running the "write-flash 0x0 images/fifty_kb.bin" command...
Executing /REDACTED/esptool/.venv/bin/python3.13 -m esptool --chip esp32s3 --port rfc2217://127.0.0.1:62474?ign_set_control --baud 921600 write-flash 0x0 images/fifty_kb.bin...
esptool v5.2.0
Serial port rfc2217://127.0.0.1:62474?ign_set_control:
Connecting...
Device VID/PID identification is only supported on COM and /dev/ serial ports.

Device VID/PID identification is only supported on COM and /dev/ serial ports.
.............................
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/REDACTED/esptool/esptool/__main__.py", line 9, in <module>
    esptool._main()
    ~~~~~~~~~~~~~^^
  File "/REDACTED/esptool/esptool/__init__.py", line 1265, in _main
    main()
    ~~~~^^
  File "/REDACTED/esptool/esptool/__init__.py", line 1233, in main
    cli(args=args, esp=esp)
    ~~~^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/esptool/cli_util.py", line 346, in __call__
    return super().__call__(*args, **kwargs)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/rich_click/rich_command.py", line 402, in __call__
    return super().__call__(*args, **kwargs)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/rich_click/rich_command.py", line 216, in main
    rv = self.invoke(ctx)
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/REDACTED/esptool/esptool/__init__.py", line 799, in write_flash_cli
    prepare_esp_object(ctx)
    ~~~~~~~~~~~~~~~~~~^^^^^
  File "/REDACTED/esptool/esptool/__init__.py", line 523, in prepare_esp_object
    esp = connect_esp(
        port=ctx.obj["port"],
    ...<6 lines>...
        open_port_attempts=open_port_attempts,
    )
  File "/REDACTED/esptool/esptool/cmds.py", line 326, in connect_esp
    esp = esp or _connect_first_available(
                 ~~~~~~~~~~~~~~~~~~~~~~~~^
        ser_list,
        ^^^^^^^^^
    ...<5 lines>...
        before=before,
        ^^^^^^^^^^^^^^
    )
    ^
  File "/REDACTED/esptool/esptool/cmds.py", line 287, in _connect_first_available
    esp.connect(before, connect_attempts)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/esptool/loader.py", line 870, in connect
    last_error = self._connect_attempt(reset_strategy, mode)
  File "/REDACTED/esptool/esptool/loader.py", line 763, in _connect_attempt
    self.sync()
    ~~~~~~~~~^^
  File "/REDACTED/esptool/esptool/loader.py", line 675, in sync
    val, _ = self.command(
             ~~~~~~~~~~~~^
        self.ESP_CMDS["SYNC"],
        ^^^^^^^^^^^^^^^^^^^^^^
        b"\x07\x07\x12\x20" + 32 * b"\x55",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        timeout=SYNC_TIMEOUT,
        ^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/REDACTED/esptool/esptool/loader.py", line 550, in command
    self._port.timeout = new_timeout
    ^^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/serial/serialutil.py", line 372, in timeout
    self._reconfigure_port()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/serial/rfc2217.py", line 516, in _reconfigure_port
    self._rfc2217_port_settings['datasize'].set(struct.pack(b'!B', self._bytesize))
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/serial/rfc2217.py", line 335, in set
    self.connection.rfc2217_send_subnegotiation(self.option, self.value)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/serial/rfc2217.py", line 867, in rfc2217_send_subnegotiation
    self._internal_raw_write(IAC + SB + COM_PORT_OPTION + option + value + IAC + SE)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/REDACTED/esptool/.venv/lib/python3.13/site-packages/serial/rfc2217.py", line 858, in _internal_raw_write
    self._socket.sendall(data)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^
ConnectionResetError: [Errno 54] Connection reset by peer

=================================================== warnings summary ===================================================
../espefuse/cli_util.py:8
  /REDACTED/esptool/espefuse/cli_util.py:8: DeprecationWarning: 'parser.OptionParser' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState, _unpack_args

../espefuse/cli_util.py:8
  /REDACTED/esptool/espefuse/cli_util.py:8: DeprecationWarning: 'parser.ParsingState' is deprecated and will be removed in Click 9.0. The old parser is available in 'optparse'.
    from click.parser import OptionParser, ParsingState, _unpack_args

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================== short test summary info ================================================
FAILED test_esptool.py::TestVirtualPort::test_auto_detect_virtual_port - subprocess.CalledProcessError: Command '['/REDACTED/esptool/.venv/bin/python3.13', '-m', 'esptool', '...
FAILED test_esptool.py::TestVirtualPort::test_highspeed_flash_virtual_port - subprocess.CalledProcessError: Command '['/REDACTED/esptool/.venv/bin/python3.13', '-m', 'esptool', '...
=========================== 2 failed, 88 passed, 31 skipped, 2 warnings in 234.13s (0:03:54) ===========================
```

</details>
